### PR TITLE
Use article submission form when creating an article manually

### DIFF
--- a/app/Resources/translations/messages.en.yml
+++ b/app/Resources/translations/messages.en.yml
@@ -1642,7 +1642,7 @@ display_mode.title: 'Title'
 display_mode.volume_and_number: 'Volume and Number'
 select.publisher: 'Select publisher'
 journal.application.domain.help.text: 'You can host your journal, if you specify a domain.'
-article.successful.create: 'Article successfully created. You can add authors from top menu.'
+article.successful.create: 'Article successfully created.'
 contact.order: 'Order'
 articles.total.view: 'Articles Total View Count'
 

--- a/app/config/assetic.yml
+++ b/app/config/assetic.yml
@@ -46,6 +46,7 @@ assetic:
         - '%kernel.root_dir%/../web/bundles/bazingajstranslation/js/translator.min.js'
         - '%kernel.root_dir%/../web/vendor/formBuilder/dist/form-builder.min.js'
         - '%kernel.root_dir%/../web/vendor/formBuilder/dist/form-render.min.js'
+        - '@OjsJournalBundle/Resources/public/js/submission.js'
     admin_main_css:
       inputs:
         - '%kernel.root_dir%/../web/vendor/bootstrap/dist/css/bootstrap.min.css'

--- a/src/Ojs/JournalBundle/Resources/config/validation/Citation.yml
+++ b/src/Ojs/JournalBundle/Resources/config/validation/Citation.yml
@@ -4,5 +4,3 @@ Ojs\JournalBundle\Entity\Citation:
             - NotBlank: { groups: [submission], message: 'Raw fields of citations can not be blank.' }
         type:
             - NotBlank: { groups: [submission], message: 'Type fields of citations can not be blank.' }
-        orderNum:
-            - NotBlank: { groups: [submission], message: 'Order number fields of citations can not be blank.' }

--- a/src/Ojs/JournalBundle/Resources/public/js/submission.js
+++ b/src/Ojs/JournalBundle/Resources/public/js/submission.js
@@ -1,0 +1,63 @@
+function setupSubmissionForm(abstractTemplates) {
+    $(function () {
+        function reviseCitationOrders() {
+            $.each($('#citation-forms-container').find('.citation-item-order'), function (index, value) {
+                $(this).html(index + 1);
+            });
+        }
+
+        reviseCitationOrders();
+        setInterval(function () {
+            reviseCitationOrders();
+        }, 1000);
+        function reviseInstitutionInputs() {
+            $.each($('.institutionNotListed'), function (index, value) {
+                var $institutionSelect = $(this).parent().parent().parent().parent().find('.institution');
+                var $institutionName = $(this).parent().parent().parent().parent().find('.institutionName');
+                if (this.checked) {
+                    $institutionName.parent().removeClass('hidden');
+                    $institutionSelect.parent().addClass('hidden');
+                } else {
+                    $institutionName.parent().addClass('hidden');
+                    $institutionSelect.parent().removeClass('hidden');
+                }
+            });
+        }
+
+        reviseInstitutionInputs();
+        setInterval(function () {
+            reviseInstitutionInputs();
+        }, 1000);
+        $(document).on('change', '.institutionNotListed', function () {
+            var $institutionSelect = $(this).parent().parent().parent().parent().find('.institution');
+            var $institutionName = $(this).parent().parent().parent().parent().find('.institutionName');
+            if (this.checked) {
+                $institutionName.parent().removeClass('hidden');
+                $institutionSelect.parent().addClass('hidden');
+            } else {
+                $institutionName.parent().addClass('hidden');
+                $institutionSelect.parent().removeClass('hidden');
+            }
+        });
+        $(document).on('click', '.toggle-author-detail', function () {
+            var $authorDetails = $(this).parent().find('.author-details');
+            if ($authorDetails.is(':visible')) {
+                $(this).find('i').removeClass('fa-arrow-up');
+                $(this).find('i').addClass('fa-arrow-down');
+                $authorDetails.hide();
+            } else {
+                $(this).find('i').removeClass('fa-arrow-down');
+                $(this).find('i').addClass('fa-arrow-up');
+                $authorDetails.show();
+            }
+        });
+
+        $.each(abstractTemplates, function (locale, abstractTemplate) {
+            var findRequiredLocaleAbstractInput = $('.a2lix_translationsFields-' + locale).find('.note-editable');
+            var abstractValue = findRequiredLocaleAbstractInput.html();
+            if (abstractValue == '<p><br></p>') {
+                findRequiredLocaleAbstractInput.html(abstractTemplate);
+            }
+        });
+    });
+}

--- a/src/Ojs/JournalBundle/Resources/views/Article/new.html.twig
+++ b/src/Ojs/JournalBundle/Resources/views/Article/new.html.twig
@@ -14,11 +14,16 @@
     <h1>{{ "article.add"|trans }}</h1>
     {% include '::flashbag.html.twig' %}
 
-    {{ form(form) }}
+    {% include '@OjsJournal/ArticleSubmission/_form.html.twig' %}
 
     <div class="record_actions">
         <a class="button success" href="{{ path('ojs_journal_article_index', {'journalId': selectedJournal().id}) }}">
             {{ "b"|trans }}
         </a>
     </div>
+
+{% endblock %}
+{% block javascripts %}
+    {{ parent() }}
+    {{ twigEventDispatch({'event_name': 'OJS_NEW_ARTICLE_SUBMISSIN_SCRIPT'})|raw }}
 {% endblock %}

--- a/src/Ojs/JournalBundle/Resources/views/Article/new.html.twig
+++ b/src/Ojs/JournalBundle/Resources/views/Article/new.html.twig
@@ -25,5 +25,10 @@
 {% endblock %}
 {% block javascripts %}
     {{ parent() }}
+
+    <script>
+        setupSubmissionForm({{ abstractTemplates|json_encode|raw }});
+    </script>
+
     {{ twigEventDispatch({'event_name': 'OJS_NEW_ARTICLE_SUBMISSIN_SCRIPT'})|raw }}
 {% endblock %}

--- a/src/Ojs/JournalBundle/Resources/views/ArticleSubmission/new.html.twig
+++ b/src/Ojs/JournalBundle/Resources/views/ArticleSubmission/new.html.twig
@@ -47,61 +47,7 @@
 {% block javascripts %}
     {{ parent() }}
     <script>
-        $(function() {
-            function reviseCitationOrders(){
-                $.each($('#citation-forms-container').find('.citation-item-order'), function (index, value) {
-                    $(this).html(index+1);
-                });
-            }
-            reviseCitationOrders();
-            setInterval(function(){ reviseCitationOrders(); }, 1000);
-            function reviseInstitutionInputs(){
-                $.each($('.institutionNotListed'), function (index, value) {
-                    var $institutionSelect = $(this).parent().parent().parent().parent().find('.institution');
-                    var $institutionName = $(this).parent().parent().parent().parent().find('.institutionName');
-                    if(this.checked){
-                        $institutionName.parent().removeClass('hidden');
-                        $institutionSelect.parent().addClass('hidden');
-                    }else{
-                        $institutionName.parent().addClass('hidden');
-                        $institutionSelect.parent().removeClass('hidden');
-                    }
-                });
-            }
-            reviseInstitutionInputs();
-            setInterval(function(){ reviseInstitutionInputs(); }, 1000);
-            $(document).on('change', '.institutionNotListed', function () {
-                var $institutionSelect = $(this).parent().parent().parent().parent().find('.institution');
-                var $institutionName = $(this).parent().parent().parent().parent().find('.institutionName');
-                if(this.checked){
-                    $institutionName.parent().removeClass('hidden');
-                    $institutionSelect.parent().addClass('hidden');
-                }else{
-                    $institutionName.parent().addClass('hidden');
-                    $institutionSelect.parent().removeClass('hidden');
-                }
-            });
-            $(document).on('click','.toggle-author-detail', function () {
-                var $authorDetails = $(this).parent().find('.author-details');
-                if($authorDetails.is(':visible')){
-                    $(this).find('i').removeClass('fa-arrow-up');
-                    $(this).find('i').addClass('fa-arrow-down');
-                    $authorDetails.hide();
-                }else{
-                    $(this).find('i').removeClass('fa-arrow-down');
-                    $(this).find('i').addClass('fa-arrow-up');
-                    $authorDetails.show();
-                }
-            });
-            var abstractTemplates = {{ abstractTemplates|json_encode|raw }};
-            $.each(abstractTemplates, function(locale, abstractTemplate){
-                var findRequiredLocaleAbstractInput = $('.a2lix_translationsFields-'+locale).find('.note-editable');
-                var abstractValue = findRequiredLocaleAbstractInput.html();
-                if(abstractValue == '<p><br></p>'){
-                    findRequiredLocaleAbstractInput.html(abstractTemplate);
-                }
-            });
-        });
+        setupSubmissionForm({{ abstractTemplates|json_encode|raw }});
     </script>
     {{ twigEventDispatch({'event_name': 'OJS_NEW_ARTICLE_SUBMISSIN_SCRIPT'})|raw }}
 {% endblock %}

--- a/src/Ojs/JournalBundle/Validator/ArticleStatusValidator.php
+++ b/src/Ojs/JournalBundle/Validator/ArticleStatusValidator.php
@@ -20,8 +20,12 @@ class ArticleStatusValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
-        /** @var Article $article */
-        $article = $this->context->getRoot()->getData();
+        $article = $this->context->getRoot();
+
+        if (!$article instanceof Article) {
+            $article = $article->getData();
+        }
+
         if($article->getId() == null){
             return;
         }


### PR DESCRIPTION
This PR replaces basic article form with the powerful one from article submission process.

- Commit 690ca95 introduces a bug fix which prevents validation from failing when an Article instance is validated by validator service. `$this->context->getRoot()` returns a form instance only when validation is triggered by a form so calling `getData()` results with failure without this change.
- Submission form's JavaScript logic moved to a new JavaScript file with commit 45872f8. That helps us to maintain DRY principle.
- Rest of the changes are all about rendering `ArticleSubmissionType` in `ArticleController::newAction()`.