### PR TITLE
"Ending Date" field for journals

### DIFF
--- a/app/Resources/translations/messages.en.yml
+++ b/app/Resources/translations/messages.en.yml
@@ -547,6 +547,7 @@ journal.editor_surname: 'Editor Surname'
 journal.eissn: 'eISSN'
 journal.email: 'Journal''s Contact E-mail'
 journal.founded: 'Founded'
+journal.endingDate: 'End Date (new submissions will not be accepted)'
 journal.file: 'Required Files'
 journal.google.analytics.id: 'Google Analytics ID'
 journal.header_image: 'Header Image'
@@ -701,7 +702,7 @@ mastersthesis: 'Master Thesis'
 messages: Messages
 message.application_not_available: 'Sorry, you can not make a new application'
 message.registration_not_available: 'Sorry, you can not make a new registration.'
-message.submission_not_available: 'Sorry, you can create a new submission.'
+message.submission_not_available: 'Sorry, you can not create a new submission.'
 mimetype: 'Mime Type'
 misc: Miscellaneous
 mission: Mission

--- a/app/Resources/translations/messages.tr.yml
+++ b/app/Resources/translations/messages.tr.yml
@@ -545,7 +545,8 @@ journal.editor_phone: Telefon
 journal.editor_surname: 'Editör Soyadı'
 journal.eissn: e-ISSN
 journal.email: 'İletişim e-Postası'
-journal.founded: 'Başlangıç'
+journal.founded: 'Başlangıç Tarihi'
+journal.endingDate: 'Bitiş Tarihi (yeni makale kabul edilmeyecektir)'
 journal.file: 'Gerekli Dosyalar'
 journal.google.analytics.id: 'Google Analytics ID'
 journal.header_image: 'Başlık Resmi'
@@ -699,7 +700,7 @@ mastersthesis: 'Yüksek Lisans Tezi'
 messages: Mesajlar
 message.application_not_available: 'Üzgünüz ama şimdilik başvuru yapmanız mümkün değil.'
 message.registration_not_available: 'Üzgünüz ama şimdilik kaydolmanız mümkün değil.'
-message.submission_not_available: 'Üzgünüz ama şimdilik Makale göndermeniz mümkün değil.'
+message.submission_not_available: 'Üzgünüz ama şimdilik makale göndermeniz mümkün değil.'
 mimetype: 'MIME Tipi'
 misc: Çeşitli
 mission: Misyon

--- a/src/Ojs/AdminBundle/Form/Type/JournalType.php
+++ b/src/Ojs/AdminBundle/Form/Type/JournalType.php
@@ -173,6 +173,24 @@ class JournalType extends AbstractType
                     ],
                 )
             )
+            ->add(
+                'endingDate',
+                'collot_datetime',
+                array(
+                    'required' => false,
+                    'label' => 'journal.endingDate',
+                    'date_format' => 'yyyy',
+                    'widget' => 'single_text',
+                    'pickerOptions' => [
+                        'format' => 'yyyy',
+                        'startView' => 'decade',
+                        'minView' => 'decade',
+                        'todayBtn' => 'true',
+                        'todayHighlight' => 'true',
+                        'autoclose' => 'true',
+                    ],
+                )
+            )
             ->add('domain')
             ->add(
                 'googleAnalyticsId',

--- a/src/Ojs/JournalBundle/Controller/ArticleSubmissionController.php
+++ b/src/Ojs/JournalBundle/Controller/ArticleSubmissionController.php
@@ -165,7 +165,8 @@ class ArticleSubmissionController extends Controller
     public function newAction(Request $request)
     {
         $journal = $this->get('ojs.journal_service')->getSelectedJournal();
-        if ($this->submissionsNotAllowed($request) || $journal->getEndingDate() !== null)  {
+        $currentTime = date('H:i:s \O\n d/m/Y');
+        if ($this->submissionsNotAllowed($request) || ($journal->getEndingDate() !== null && $currentTime<$journal->getEndingDate()))  {
             return $this->respondAsNotAllowed();
         }
         $em = $this->getDoctrine()->getManager();
@@ -595,7 +596,8 @@ class ArticleSubmissionController extends Controller
     {
         $journal = $this->get('ojs.journal_service')->getSelectedJournal();
         $em = $this->getDoctrine();
-        if ($this->submissionsNotAllowed($request) || $journal->getEndingDate() !== null) {
+        $currentTime = date('H:i:s \O\n d/m/Y');
+        if ($this->submissionsNotAllowed($request) || ($journal->getEndingDate() !== null && $currentTime<$journal->getEndingDate()))  {
             return $this->respondAsNotAllowed();
         }
         $session = $this->get('session');

--- a/src/Ojs/JournalBundle/Controller/ArticleSubmissionController.php
+++ b/src/Ojs/JournalBundle/Controller/ArticleSubmissionController.php
@@ -165,7 +165,7 @@ class ArticleSubmissionController extends Controller
     public function newAction(Request $request)
     {
         $journal = $this->get('ojs.journal_service')->getSelectedJournal();
-        if ($this->submissionsNotAllowed($request)) {
+        if ($this->submissionsNotAllowed($request) || $journal->getEndingDate() !== null)  {
             return $this->respondAsNotAllowed();
         }
         $em = $this->getDoctrine()->getManager();
@@ -595,7 +595,7 @@ class ArticleSubmissionController extends Controller
     {
         $journal = $this->get('ojs.journal_service')->getSelectedJournal();
         $em = $this->getDoctrine();
-        if ($this->submissionsNotAllowed($request)) {
+        if ($this->submissionsNotAllowed($request) || $journal->getEndingDate() !== null) {
             return $this->respondAsNotAllowed();
         }
         $session = $this->get('session');

--- a/src/Ojs/JournalBundle/Entity/Journal.php
+++ b/src/Ojs/JournalBundle/Entity/Journal.php
@@ -102,6 +102,11 @@ class Journal extends AbstractTranslatable
      */
     private $founded;
     /**
+     * @var \DateTime
+     * @JMS\Expose
+     */
+    private $endingDate;
+    /**
      * @var string
      * @JMS\Expose
      */
@@ -698,6 +703,22 @@ class Journal extends AbstractTranslatable
         $this->founded = $founded;
 
         return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getEndingDate()
+    {
+        return $this->endingDate;
+    }
+
+    /**
+     * @param \DateTime $endingDate
+     */
+    public function setEndingDate($endingDate)
+    {
+        $this->endingDate = $endingDate;
     }
 
     /**

--- a/src/Ojs/JournalBundle/Form/Type/JournalType.php
+++ b/src/Ojs/JournalBundle/Form/Type/JournalType.php
@@ -160,6 +160,24 @@ class JournalType extends AbstractType
                     ],
                 )
             )
+            ->add(
+                'endingDate',
+                'collot_datetime',
+                array(
+                    'required' => false,
+                    'label' => 'journal.endingDate',
+                    'date_format' => 'yyyy',
+                    'widget' => 'single_text',
+                    'pickerOptions' => [
+                        'format' => 'yyyy',
+                        'startView' => 'decade',
+                        'minView' => 'decade',
+                        'todayBtn' => 'true',
+                        'todayHighlight' => 'true',
+                        'autoclose' => 'true',
+                    ],
+                )
+            )
             ->add('domain', null, ['label' => 'journal.domain'])
             ->add(
                 'googleAnalyticsId',

--- a/src/Ojs/JournalBundle/Resources/config/doctrine/Journal.orm.yml
+++ b/src/Ojs/JournalBundle/Resources/config/doctrine/Journal.orm.yml
@@ -221,6 +221,10 @@ Ojs\JournalBundle\Entity\Journal:
       type: datetime
       column: founded
       nullable: true
+    endingDate:
+      type: datetime
+      column: ending_date
+      nullable: true
     url:
       type: string
       length: 255


### PR DESCRIPTION
This PR introduces a new field with the name "ending date" that allows journal managers to specify end dates of their publication. _Ended_ journals will not accept new submissions.

- Commit 80eab79 introduces the field, its basic logic and necessary translation strings.
- Commit 576556f by @hmert improves the logic which disallows new submissions.