### PR TITLE
Don't allow users to interfere with article status

### DIFF
--- a/src/Ojs/JournalBundle/Controller/ArticleController.php
+++ b/src/Ojs/JournalBundle/Controller/ArticleController.php
@@ -6,6 +6,7 @@ use APY\DataGridBundle\Grid\Column\ActionsColumn;
 use APY\DataGridBundle\Grid\Row;
 use APY\DataGridBundle\Grid\Source\Entity;
 use Ojs\CoreBundle\Controller\OjsController as Controller;
+use Ojs\CoreBundle\Params\ArticleStatuses;
 use Ojs\JournalBundle\Entity\Article;
 use Ojs\JournalBundle\Entity\Journal;
 use Ojs\JournalBundle\Event\JournalItemEvent;
@@ -174,6 +175,7 @@ class ArticleController extends Controller
         if ($form->isValid()) {
             $em = $this->getDoctrine()->getManager();
             $entity->setCurrentLocale($request->getDefaultLocale());
+            $entity->setStatus(ArticleStatuses::STATUS_PUBLISH_READY);
 
             $event = new JournalItemEvent($entity);
             $dispatcher->dispatch(ArticleEvents::PRE_CREATE, $event);

--- a/src/Ojs/JournalBundle/Controller/ArticleSubmissionController.php
+++ b/src/Ojs/JournalBundle/Controller/ArticleSubmissionController.php
@@ -532,7 +532,8 @@ class ArticleSubmissionController extends Controller
             if ($session->has('submissionFiles')) {
                 $session->remove('submissionFiles');
             }
-            $article->setStatus(ArticleStatuses::STATUS_INREVIEW);
+
+            $article->setStatus(ArticleStatuses::STATUS_PUBLISH_READY);
             $article->setSubmissionDate(new \DateTime());
             $em->persist($article);
 

--- a/src/Ojs/JournalBundle/Controller/IssueController.php
+++ b/src/Ojs/JournalBundle/Controller/IssueController.php
@@ -8,6 +8,7 @@ use APY\DataGridBundle\Grid\Row;
 use APY\DataGridBundle\Grid\Source\Entity;
 use Doctrine\ORM\Query;
 use Ojs\CoreBundle\Controller\OjsController as Controller;
+use Ojs\CoreBundle\Params\ArticleStatuses;
 use Ojs\JournalBundle\Entity\Article;
 use Ojs\JournalBundle\Entity\ArticleRepository;
 use Ojs\JournalBundle\Entity\Issue;
@@ -542,6 +543,7 @@ class IssueController extends Controller
         }
 
         $article->setIssue($issue);
+        $article->setStatus(ArticleStatuses::STATUS_PUBLISHED);
 
         if ($section) {
             $sections = $issue->getSections();

--- a/src/Ojs/JournalBundle/Entity/ArticleRepository.php
+++ b/src/Ojs/JournalBundle/Entity/ArticleRepository.php
@@ -18,6 +18,7 @@ class ArticleRepository extends EntityRepository
      */
     public function getArticlesUnissued($statuses = [
         ArticleStatuses::STATUS_PUBLISHED,
+        ArticleStatuses::STATUS_PUBLISH_READY,
         ArticleStatuses::STATUS_EARLY_PREVIEW,
     ])
     {

--- a/src/Ojs/JournalBundle/Form/Type/ArticleType.php
+++ b/src/Ojs/JournalBundle/Form/Type/ArticleType.php
@@ -75,15 +75,6 @@ class ArticleType extends AbstractType
                 )
             )
             ->add(
-                'status',
-                'choice',
-                array(
-                    'label' => 'status',
-                    'attr' => array('class' => ' form-control'),
-                    'choices' => Article::$statuses,
-                )
-            )
-            ->add(
                 'doi',
                 'text',
                 array(

--- a/src/Ojs/JournalBundle/Resources/config/validation/Article.yml
+++ b/src/Ojs/JournalBundle/Resources/config/validation/Article.yml
@@ -36,7 +36,6 @@ Ojs\JournalBundle\Entity\Article:
                 minMessage: "must.specify.least.one.article.citation"
                 maxMessage: "You cannot specify more than {{ limit }} citation"
         status:
-            - NotBlank: ~
             - Ojs\JournalBundle\Validator\Constraints\ArticleStatus: { message: 'article.status_can_not_be_published_without_author'}
         submissionDate:
             - NotBlank: ~


### PR DESCRIPTION
The title is pretty straightforward. This PR automatically takes care of the status field instead of letting the user meddle with it.