### PR TITLE
Feature/journal name change

### DIFF
--- a/app/Resources/translations/messages.en.yml
+++ b/app/Resources/translations/messages.en.yml
@@ -1648,6 +1648,8 @@ article.successful.create: 'Article successfully created. You can add authors fr
 contact.order: 'Order'
 articles.total.view: 'Articles Total View Count'
 articles.total.download: 'Articles Total Download Count'
+formerly.known.as: 'Formerly known as'
+continued.as.journal: 'Continued as'
 
 # OAuth
 linkedin: 'Linkedin'

--- a/app/Resources/translations/messages.tr.yml
+++ b/app/Resources/translations/messages.tr.yml
@@ -1648,6 +1648,8 @@ Secretary: 'Sekreter'
 contact.order: 'Sıra'
 articles.total.view: 'Makalelerin Toplam Gösterim Sayısı'
 articles.total.downlaod: 'Makalelerin Toplam İndirilme Sayısı'
+formerly.known.as: 'Dergi eski adı'
+continued.as.journal: 'Dergi yeni adı'
 
 # OAuth
 linkedin: 'Linkedin'

--- a/src/Ojs/AdminBundle/Controller/AdminJournalController.php
+++ b/src/Ojs/AdminBundle/Controller/AdminJournalController.php
@@ -281,6 +281,14 @@ class AdminJournalController extends Controller
         $q = filter_var($request->get('q'), FILTER_SANITIZE_STRING);
         $search = $this->get('fos_elastica.index.search.journal');
 
+        $notCollectJournals = [];
+        if($request->query->has('notCollectJournals')){
+            $notCollectJournalsParam = $request->query->get('notCollectJournals');
+            if(!empty($notCollectJournalsParam) && is_array($notCollectJournalsParam)){
+                $notCollectJournals = $notCollectJournalsParam;
+            }
+        }
+
         $searchQuery = new Query('_all');
 
         $boolQuery = new Query\BoolQuery();
@@ -298,10 +306,12 @@ class AdminJournalController extends Controller
         $results = $search->search($searchQuery);
         $data = [];
         foreach ($results as $result) {
-            $data[] = [
-                'id' => $result->getId(),
-                'text' => $result->getData()['title'],
-            ];
+            if(!in_array($result->getId(), $notCollectJournals)){
+                $data[] = [
+                    'id' => $result->getId(),
+                    'text' => $result->getData()['title'],
+                ];
+            }
         }
 
         return new JsonResponse($data);

--- a/src/Ojs/AdminBundle/Form/Type/JournalEditType.php
+++ b/src/Ojs/AdminBundle/Form/Type/JournalEditType.php
@@ -136,6 +136,25 @@ class JournalEditType extends AbstractType
                 'required' => false,
                 ]
             )
+            ->add(
+                'continuedAsJournal',
+                'tetranz_select2entity',
+                [
+                    'empty_data' => null,
+                    'remote_route' => 'ojs_admin_journal_autocomplete',
+                    'class' => 'Ojs\JournalBundle\Entity\Journal',
+                    'label' => 'continuedAsJournal',
+                    'attr' => [
+                        'class' => 'select2-element',
+                    ],
+                    'allow_clear' => true,
+                    'remote_params' => [
+                        'notCollectJournals' => [
+                            $builder->getData()->getId()
+                        ]
+                    ]
+                ]
+            )
             ->add('note', 'textarea', [
                     'label' => 'journal.note',
                     'required' => false,

--- a/src/Ojs/JournalBundle/Entity/Journal.php
+++ b/src/Ojs/JournalBundle/Entity/Journal.php
@@ -310,6 +310,16 @@ class Journal extends AbstractTranslatable
     private $extraFields;
 
     /**
+     * @var Journal
+     */
+    private $continuedAsJournal;
+
+    /**
+     * @var Journal
+     */
+    private $formerlyKnownAsJournal;
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -1608,6 +1618,60 @@ class Journal extends AbstractTranslatable
     public function setTotalArticleDownload($totalArticleDownload)
     {
         $this->totalArticleDownload = $totalArticleDownload;
+
+        return $this;
+    }
+
+    /**
+     * @return Journal
+     */
+    public function getContinuedAsJournal()
+    {
+        return $this->continuedAsJournal;
+    }
+
+    /**
+     * @param Journal $continuedAsJournal
+     *
+     * @return $this
+     */
+    public function setContinuedAsJournal($continuedAsJournal)
+    {
+        $oldContinuedAsJournal = $this->continuedAsJournal;
+        $this->continuedAsJournal = $continuedAsJournal;
+        if($continuedAsJournal instanceof Journal
+            && empty($continuedAsJournal->getFormerlyKnownAsJournal())){
+            $continuedAsJournal->setFormerlyKnownAsJournal($this);
+        }elseif(empty($continuedAsJournal) && !empty($oldContinuedAsJournal)){
+            $continuedAsJournal->setFormerlyKnownAsJournal(null);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Journal
+     */
+    public function getFormerlyKnownAsJournal()
+    {
+        return $this->formerlyKnownAsJournal;
+    }
+
+    /**
+     * @param Journal $formerlyKnownAsJournal
+     *
+     * @return $this
+     */
+    public function setFormerlyKnownAsJournal($formerlyKnownAsJournal)
+    {
+        $oldFormerlyKnownAsJournal = $this->formerlyKnownAsJournal;
+        $this->formerlyKnownAsJournal = $formerlyKnownAsJournal;
+        if($formerlyKnownAsJournal instanceof Journal
+            && empty($formerlyKnownAsJournal->getContinuedAsJournal())){
+            $formerlyKnownAsJournal->setContinuedAsJournal($this);
+        }elseif(empty($formerlyKnownAsJournal) && !empty($oldFormerlyKnownAsJournal)){
+            $formerlyKnownAsJournal->setContinuedAsJournal(null);
+        }
 
         return $this;
     }

--- a/src/Ojs/JournalBundle/Resources/config/doctrine/Journal.orm.yml
+++ b/src/Ojs/JournalBundle/Resources/config/doctrine/Journal.orm.yml
@@ -20,6 +20,18 @@ Ojs\JournalBundle\Entity\Journal:
       joinColumn:
         name: theme_id
         referencedColumnName: id
+    continuedAsJournal:
+      targetEntity: Ojs\JournalBundle\Entity\Journal
+      joinColumn:
+        name: continued_as_journal_id
+        referencedColumnName: id
+        nullable: true
+    formerlyKnownAsJournal:
+      targetEntity: Ojs\JournalBundle\Entity\Journal
+      joinColumn:
+        name: formerly_known_as_journal_id
+        referencedColumnName: id
+        nullable: true
     design:
       targetEntity: Ojs\JournalBundle\Entity\Design
       joinColumn:

--- a/src/Ojs/SiteBundle/Resources/views/Journal/journal_index.html.twig
+++ b/src/Ojs/SiteBundle/Resources/views/Journal/journal_index.html.twig
@@ -100,6 +100,25 @@
                         <a href="{{ journal.url }}" target="_blank">
                             <small>{{ journal.url }}</small>
                         </a>
+                        <br>
+                    {% endif %}
+                    {% if journal.formerlyKnownAsJournal is not empty %}
+                        <b>
+                            {{ 'formerly.known.as'|trans }}:
+                            <a href="{{ path('ojs_journal_index', {slug: journal.formerlyKnownAsJournal.slug }) }}">
+                                {{ journal.formerlyKnownAsJournal.title }}
+                            </a>
+                        </b>
+                        <br>
+                    {% endif %}
+                    {% if journal.continuedAsJournal is not empty %}
+                        <b>
+                            {{ 'continued.as.journal'|trans }}:
+                            <a href="{{ path('ojs_journal_index', {slug: journal.continuedAsJournal.slug }) }}">
+                                {{ journal.continuedAsJournal.title }}
+                            </a>
+                        </b>
+                        <br>
                     {% endif %}
                     {{ journal.description|raw }}
                 </div>


### PR DESCRIPTION
setup `formerly known as` and `continued as` journal logic.

Related ss;

![image](https://cloud.githubusercontent.com/assets/4572080/18692314/04ecab40-7fa2-11e6-8a15-29cf43011e4e.png)

Related links;
 - http://www.sciencedirect.com/science/journal/09613552/13/4