### PR TITLE
Change tag delimiter

### DIFF
--- a/src/Ojs/CoreBundle/Form/DataTransformer/TagsTransformer.php
+++ b/src/Ojs/CoreBundle/Form/DataTransformer/TagsTransformer.php
@@ -5,29 +5,20 @@ namespace Ojs\CoreBundle\Form\DataTransformer;
 use Symfony\Component\Form\DataTransformerInterface;
 
 /**
- *
  * Class TagsTransformer
  * @package Ojs\CoreBundle\Form\DataTransformer
  */
 class TagsTransformer implements DataTransformerInterface
 {
-    private $delimiter = ',';
+    private $delimiter = ';';
+
     public function transform($tagsData)
     {
-        if(empty($tagsData)) {
-            return null;
-        }
-        $parts = explode($this->delimiter, $tagsData);
-
-        return $parts;
+        return empty($tagsData) ? null : explode($this->delimiter, $tagsData);
     }
-
 
     public function reverseTransform($values = null)
     {
-        if(empty($values) || !is_array($values)){
-            return null;
-        }
-        return implode($this->delimiter, $values);
+        return empty($values) || !is_array($values) ? null : implode($this->delimiter, $values);
     }
 }


### PR DESCRIPTION
Users noted that they prefer `;` as the tag delimiter instead of `,` since it is rarer.