### PR TITLE
Mailer refactor

### DIFF
--- a/src/Ojs/AdminBundle/EventListener/AdminEventListener.php
+++ b/src/Ojs/AdminBundle/EventListener/AdminEventListener.php
@@ -21,21 +21,21 @@ class AdminEventListener implements EventSubscriberInterface
     private $em;
 
     /** @var Mailer */
-    private $ojsMailer;
+    private $mailer;
 
     /**
      * @param RouterInterface $router
      * @param EntityManager $em
-     * @param Mailer $ojsMailer
+     * @param Mailer $mailer
      */
     public function __construct(
         RouterInterface $router,
         EntityManager $em,
-        Mailer $ojsMailer
+        Mailer $mailer
     ) {
         $this->router = $router;
         $this->em = $em;
-        $this->ojsMailer = $ojsMailer;
+        $this->mailer = $mailer;
     }
 
     /**
@@ -78,7 +78,7 @@ class AdminEventListener implements EventSubscriberInterface
     public function onUserChangeCreate(AdminEvent $event)
     {
         $name = AdminEvents::ADMIN_USER_CHANGE_CREATE.'.created.user';
-        $this->ojsMailer->sendEventMail($name, [$event->getEntity()], []);
+        $this->mailer->sendEventMail($name, [$event->getEntity()], []);
     }
 
     /**
@@ -105,11 +105,11 @@ class AdminEventListener implements EventSubscriberInterface
         $this->sendAdminMail(AdminEvents::JOURNAL_APPLICATION_HAPPEN, [], ['journal.title' => $journal->getTitle()]);
 
         // ... and then the applicant user.
-        if ($this->ojsMailer->currentUser() instanceof UserInterface){
-            $user = $this->ojsMailer->currentUser();
+        if ($this->mailer->currentUser() instanceof UserInterface){
+            $user = $this->mailer->currentUser();
         } else {
             $user = new User();
-            $username = $this->ojsMailer->translator->trans('journal.manager');
+            $username = $this->mailer->translator->trans('journal.manager');
             $user->setEmail($journal->getEmail())->setUsername($username);
         }
 
@@ -119,7 +119,7 @@ class AdminEventListener implements EventSubscriberInterface
             'journal.address' => $journal->getAddress(),
         ];
 
-        $this->ojsMailer->sendEventMail(AdminEvents::JOURNAL_APPLICATION_HAPPEN.'.application.user', [$user], $params, null);
+        $this->mailer->sendEventMail(AdminEvents::JOURNAL_APPLICATION_HAPPEN.'.application.user', [$user], $params, null);
     }
 
     /**
@@ -188,7 +188,7 @@ class AdminEventListener implements EventSubscriberInterface
         array $extraUsers = [],
         array $extraParams = []
     ) {
-        $users = array_merge($this->ojsMailer->getAdmins(), $extraUsers);
-        $this->ojsMailer->sendEventMail($name, $users, $extraParams, null);
+        $users = array_merge($this->mailer->getAdmins(), $extraUsers);
+        $this->mailer->sendEventMail($name, $users, $extraParams, null);
     }
 }

--- a/src/Ojs/AdminBundle/EventListener/AdminEventListener.php
+++ b/src/Ojs/AdminBundle/EventListener/AdminEventListener.php
@@ -6,7 +6,7 @@ use Doctrine\ORM\EntityManager;
 use FOS\UserBundle\Model\UserInterface;
 use Ojs\AdminBundle\Events\AdminEvent;
 use Ojs\AdminBundle\Events\AdminEvents;
-use Ojs\CoreBundle\Service\OjsMailer;
+use Ojs\CoreBundle\Service\Mailer;
 use Ojs\JournalBundle\Entity\Journal;
 use Ojs\UserBundle\Entity\User;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -20,19 +20,19 @@ class AdminEventListener implements EventSubscriberInterface
     /** @var EntityManager */
     private $em;
 
-    /** @var OjsMailer */
+    /** @var Mailer */
     private $ojsMailer;
 
     /**
      * @param RouterInterface $router
      * @param EntityManager $em
-     * @param OjsMailer $ojsMailer
-     *
+     * @param Mailer $ojsMailer
+
      */
     public function __construct(
         RouterInterface $router,
         EntityManager $em,
-        OjsMailer $ojsMailer
+        Mailer $ojsMailer
     ) {
         $this->router = $router;
         $this->em = $em;

--- a/src/Ojs/AdminBundle/EventListener/AdminEventListener.php
+++ b/src/Ojs/AdminBundle/EventListener/AdminEventListener.php
@@ -62,7 +62,7 @@ class AdminEventListener implements EventSubscriberInterface
      */
     public function onUserChange(AdminEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(AdminEvents::ADMIN_USER_CHANGE);
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(AdminEvents::ADMIN_USER_CHANGE);
         if(!$getMailEvent){
             return;
         }
@@ -91,7 +91,7 @@ class AdminEventListener implements EventSubscriberInterface
      */
     public function onUserChangeCreate(AdminEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(AdminEvents::ADMIN_USER_CHANGE_CREATE.'.created.user');
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(AdminEvents::ADMIN_USER_CHANGE_CREATE.'.created.user');
         if(!$getMailEvent){
             return;
         }
@@ -115,7 +115,7 @@ class AdminEventListener implements EventSubscriberInterface
      */
     public function onJournalContactChange(AdminEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(AdminEvents::ADMIN_CONTACT_CHANGE);
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(AdminEvents::ADMIN_CONTACT_CHANGE);
         if(!$getMailEvent){
             return;
         }
@@ -143,7 +143,7 @@ class AdminEventListener implements EventSubscriberInterface
     {
         /** @var Journal $journal */
         $journal = $event->getEntity();
-        $getMailEvent = $this->ojsMailer->getEventByName(AdminEvents::JOURNAL_APPLICATION_HAPPEN);
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(AdminEvents::JOURNAL_APPLICATION_HAPPEN);
         if(!$getMailEvent){
             goto lookforapplicationuser;
         }
@@ -164,7 +164,7 @@ class AdminEventListener implements EventSubscriberInterface
         lookforapplicationuser:
 
         //send to applier user
-        $getMailEvent = $this->ojsMailer->getEventByName(AdminEvents::JOURNAL_APPLICATION_HAPPEN.'.application.user');
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(AdminEvents::JOURNAL_APPLICATION_HAPPEN.'.application.user');
         if(!$getMailEvent){
             return;
         }
@@ -195,7 +195,7 @@ class AdminEventListener implements EventSubscriberInterface
      */
     public function onJournalChange(AdminEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(AdminEvents::ADMIN_JOURNAL_CHANGE);
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(AdminEvents::ADMIN_JOURNAL_CHANGE);
         if(!$getMailEvent){
             return;
         }
@@ -221,7 +221,7 @@ class AdminEventListener implements EventSubscriberInterface
      */
     public function onPublisherApplicationHappen(AdminEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(AdminEvents::PUBLISHER_APPLICATION_HAPPEN);
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(AdminEvents::PUBLISHER_APPLICATION_HAPPEN);
         if(!$getMailEvent){
             return;
         }
@@ -245,7 +245,7 @@ class AdminEventListener implements EventSubscriberInterface
      */
     public function onPublisherChange(AdminEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(AdminEvents::PUBLISHER_CHANGE);
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(AdminEvents::PUBLISHER_CHANGE);
         if(!$getMailEvent){
             return;
         }
@@ -271,7 +271,7 @@ class AdminEventListener implements EventSubscriberInterface
      */
     public function onAdminSubjectChange(AdminEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(AdminEvents::ADMIN_SUBJECT_CHANGE);
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(AdminEvents::ADMIN_SUBJECT_CHANGE);
         if(!$getMailEvent){
             return;
         }
@@ -297,7 +297,7 @@ class AdminEventListener implements EventSubscriberInterface
      */
     public function onSettingsChange(AdminEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(AdminEvents::SETTINGS_CHANGE);
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(AdminEvents::SETTINGS_CHANGE);
         if(!$getMailEvent){
             return;
         }

--- a/src/Ojs/AdminBundle/EventListener/AdminEventListener.php
+++ b/src/Ojs/AdminBundle/EventListener/AdminEventListener.php
@@ -66,7 +66,7 @@ class AdminEventListener implements EventSubscriberInterface
         if(!$getMailEvent){
             return;
         }
-        foreach ($this->ojsMailer->getAdminUsers() as $user) {
+        foreach ($this->ojsMailer->getAdmins() as $user) {
             /** @var User $entity */
             $entity = $event->getEntity();
             $transformParams = [
@@ -119,7 +119,7 @@ class AdminEventListener implements EventSubscriberInterface
         if(!$getMailEvent){
             return;
         }
-        foreach ($this->ojsMailer->getAdminUsers() as $user) {
+        foreach ($this->ojsMailer->getAdmins() as $user) {
             $transformParams = [
                 'contact'           => (string)$event->getEntity(),
                 'eventType'         => $event->getEventType(),
@@ -148,7 +148,7 @@ class AdminEventListener implements EventSubscriberInterface
             goto lookforapplicationuser;
         }
         //send to admin user group
-        foreach ($this->ojsMailer->getAdminUsers() as $user) {
+        foreach ($this->ojsMailer->getAdmins() as $user) {
             $transformParams = [
                 'journal.title'     => $journal->getTitle(),
                 'receiver.username' => $user->getUsername(),
@@ -199,7 +199,7 @@ class AdminEventListener implements EventSubscriberInterface
         if(!$getMailEvent){
             return;
         }
-        foreach ($this->ojsMailer->getAdminUsers() as $user) {
+        foreach ($this->ojsMailer->getAdmins() as $user) {
             $transformParams = [
                 'journal.title'     => $event->getEntity()->getTitle(),
                 'eventType'         => $event->getEventType(),
@@ -225,7 +225,7 @@ class AdminEventListener implements EventSubscriberInterface
         if(!$getMailEvent){
             return;
         }
-        foreach ($this->ojsMailer->getAdminUsers() as $user) {
+        foreach ($this->ojsMailer->getAdmins() as $user) {
             $transformParams = [
                 'publisher.name'   => $event->getEntity()->getName(),
                 'receiver.username' => $user->getUsername(),
@@ -249,7 +249,7 @@ class AdminEventListener implements EventSubscriberInterface
         if(!$getMailEvent){
             return;
         }
-        foreach ($this->ojsMailer->getAdminUsers() as $user) {
+        foreach ($this->ojsMailer->getAdmins() as $user) {
             $transformParams = [
                 'publisher.name'   => $event->getEntity()->getName(),
                 'eventType'         => $event->getEventType(),
@@ -275,7 +275,7 @@ class AdminEventListener implements EventSubscriberInterface
         if(!$getMailEvent){
             return;
         }
-        foreach ($this->ojsMailer->getAdminUsers() as $user) {
+        foreach ($this->ojsMailer->getAdmins() as $user) {
             $transformParams = [
                 'subject.subject'   => $event->getEntity()->getSubject(),
                 'eventType'         => $event->getEventType(),
@@ -301,7 +301,7 @@ class AdminEventListener implements EventSubscriberInterface
         if(!$getMailEvent){
             return;
         }
-        foreach ($this->ojsMailer->getAdminUsers() as $user) {
+        foreach ($this->ojsMailer->getAdmins() as $user) {
             $transformParams = [
                 'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
                 'receiver.username' => $user->getUsername(),

--- a/src/Ojs/CoreBundle/EventListener/CoreEventListener.php
+++ b/src/Ojs/CoreBundle/EventListener/CoreEventListener.php
@@ -56,7 +56,7 @@ class CoreEventListener implements EventSubscriberInterface
         if(!$getMailEvent){
             return;
         }
-        foreach ($this->ojsMailer->getAdminUsers() as $user) {
+        foreach ($this->ojsMailer->getAdmins() as $user) {
             $transformParams = [
                 'bundleName'        => $event->getBundleName(),
                 'receiver.username' => $user->getUsername(),

--- a/src/Ojs/CoreBundle/EventListener/CoreEventListener.php
+++ b/src/Ojs/CoreBundle/EventListener/CoreEventListener.php
@@ -52,7 +52,7 @@ class CoreEventListener implements EventSubscriberInterface
      */
     public function onInstall3Party(CoreEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(CoreEvents::OJS_INSTALL_BASE);
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(CoreEvents::OJS_INSTALL_BASE);
         if(!$getMailEvent){
             return;
         }

--- a/src/Ojs/CoreBundle/EventListener/CoreEventListener.php
+++ b/src/Ojs/CoreBundle/EventListener/CoreEventListener.php
@@ -5,7 +5,7 @@ namespace Ojs\CoreBundle\EventListener;
 use Doctrine\ORM\EntityManager;
 use Ojs\CoreBundle\Events\CoreEvent;
 use Ojs\CoreBundle\Events\CoreEvents;
-use Ojs\CoreBundle\Service\OjsMailer;
+use Ojs\CoreBundle\Service\Mailer;
 use Ojs\UserBundle\Entity\User;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
@@ -18,19 +18,19 @@ class CoreEventListener implements EventSubscriberInterface
     /** @var EntityManager */
     private $em;
 
-    /** @var OjsMailer */
+    /** @var Mailer */
     private $ojsMailer;
 
     /**
      * @param RouterInterface $router
      * @param EntityManager $em
-     * @param OjsMailer $ojsMailer
-     *
+     * @param Mailer $ojsMailer
+
      */
     public function __construct(
         RouterInterface $router,
         EntityManager $em,
-        OjsMailer $ojsMailer
+        Mailer $ojsMailer
     ) {
         $this->router = $router;
         $this->em = $em;

--- a/src/Ojs/CoreBundle/Resources/config/services.yml
+++ b/src/Ojs/CoreBundle/Resources/config/services.yml
@@ -26,7 +26,7 @@ services:
     arguments: ["@security.role_hierarchy", "@security.authentication.trust_resolver", "@ojs.journal_service"]
 
   ojs_mailer:
-    class: Ojs\CoreBundle\Service\OjsMailer
+    class: Ojs\CoreBundle\Service\Mailer
     arguments:
       - "@mailer"
       - "%system_email%"

--- a/src/Ojs/CoreBundle/Service/Mailer.php
+++ b/src/Ojs/CoreBundle/Service/Mailer.php
@@ -213,7 +213,15 @@ class Mailer
 
         $template = $this->em->getRepository(MailTemplate::class)->findOneBy($criteria);
 
-        if ($template == null) {
+        if ($template === null) {
+            if ($journal !== null) {
+                return $this->getTemplateByEvent($eventName, $lang);
+            }
+
+            if ($lang !== null) {
+                return $this->getTemplateByEvent($eventName);
+            }
+
             return null;
         } elseif ($template->isUseJournalDefault()) {
             $GLOBALS[$globalKey] = false;

--- a/src/Ojs/CoreBundle/Service/Mailer.php
+++ b/src/Ojs/CoreBundle/Service/Mailer.php
@@ -11,7 +11,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
-class OjsMailer
+class Mailer
 {
     /**
      * @var \Swift_Mailer
@@ -54,7 +54,7 @@ class OjsMailer
     public $preventMailMerge;
 
     /**
-     * OjsMailer constructor.
+     * Mailer constructor.
      *
      * @param \Swift_Mailer         $mailer
      * @param string                $mailSender

--- a/src/Ojs/CoreBundle/Service/Mailer.php
+++ b/src/Ojs/CoreBundle/Service/Mailer.php
@@ -101,16 +101,15 @@ class Mailer
             return;
         }
 
-        $body = $this->transformTemplate($template->getTemplate(), $templateParams);
-
         /** @var User $user */
         foreach ($users as $user) {
-            array_merge($templateParams, [
+            $templateParams = array_merge([
                 'receiver.username' => $user->getUsername(),
                 'receiver.fullName' => $user->getFullName(),
                 'done.by' => $this->currentUser()->getUsername(),
-            ]);
+            ], $templateParams);
 
+            $body = $this->transformTemplate($template->getTemplate(), $templateParams);
             $this->sendToUser($user, $template->getSubject(), $body);
         }
     }

--- a/src/Ojs/CoreBundle/Service/Mailer.php
+++ b/src/Ojs/CoreBundle/Service/Mailer.php
@@ -93,15 +93,11 @@ class Mailer
      */
     public function sendToUser(User $user, $subject, $body)
     {
-        if(
-            !empty($subject)
-            && !empty($body)
-            && !empty($user->getEmail())
-            && !empty($user->getUsername())
-        ){
-            if($this->preventMailMerge){
-                $subject = $subject.' rand:'.rand(0,10000);
-            }
+        $mailOk = !empty($subject) && !empty($body);
+        $userOk = !empty($user->getEmail()) && !empty($user->getUsername());
+
+        if ($mailOk && $userOk){
+            $subject = $this->preventMailMerge ? $subject.' rand:'.rand(0, 10000) : $subject;
             $this->send($subject, $body, $user->getEmail(), $user->getUsername());
         }
     }
@@ -143,16 +139,16 @@ class Mailer
      */
     public function getJournalRelatedUsers()
     {
-        return $this->em->getRepository('OjsUserBundle:User')->findUsersByJournalRole(
-            ['ROLE_JOURNAL_MANAGER', 'ROLE_EDITOR', 'ROLE_CO_EDITOR']
-        );
+        $roles = ['ROLE_JOURNAL_MANAGER', 'ROLE_EDITOR', 'ROLE_CO_EDITOR'];
+        return $this->em->getRepository('OjsUserBundle:User')->findUsersByJournalRole($roles);
     }
 
-    public function transformTemplate($template, $transformParams = [])
+    public function transformTemplate($template, $parameters = [])
     {
-        foreach($transformParams as $transformKey => $transformParam){
-            $template = str_replace('[['.$transformKey.']]', $transformParam, $template);
+        foreach ($parameters as $key => $value) {
+            $template = str_replace('[['.$key.']]', $value, $template);
         }
+
         return $template;
     }
 
@@ -162,9 +158,11 @@ class Mailer
     public function currentUser()
     {
         $token = $this->tokenStorage->getToken();
-        if(!$token){
-            throw new \LogicException('i can not find current user token :/');
+
+        if (!$token) {
+            throw new \LogicException("Could not find a token for the current user.");
         }
+
         return $token->getUser();
     }
 

--- a/src/Ojs/CoreBundle/Service/Mailer.php
+++ b/src/Ojs/CoreBundle/Service/Mailer.php
@@ -120,27 +120,20 @@ class Mailer
     }
 
     /**
-     * @return \Doctrine\Common\Collections\Collection | User[]
-     * @link http://stackoverflow.com/a/16692911
+     * @return \Doctrine\Common\Collections\Collection|User[]
      */
-    public function getAdminUsers()
+    public function getAdmins()
     {
-        $qb = $this->em->createQueryBuilder();
-        $qb->select('u')
-            ->from('OjsUserBundle:User', 'u')
-            ->where('u.roles LIKE :roles')
-            ->setParameter('roles', '%ROLE_SUPER_ADMIN%');
-
-        return $qb->getQuery()->getResult();
+        return $this->em->getRepository(User::class)->findAdmins();
     }
 
     /**
      * @return mixed
      */
-    public function getJournalRelatedUsers()
+    public function getJournalStaff()
     {
         $roles = ['ROLE_JOURNAL_MANAGER', 'ROLE_EDITOR', 'ROLE_CO_EDITOR'];
-        return $this->em->getRepository('OjsUserBundle:User')->findUsersByJournalRole($roles);
+        return $this->em->getRepository(User::class)->findUsersByJournalRole($roles);
     }
 
     public function transformTemplate($template, $parameters = [])

--- a/src/Ojs/CoreBundle/Service/Mailer.php
+++ b/src/Ojs/CoreBundle/Service/Mailer.php
@@ -225,7 +225,7 @@ class Mailer
             return null;
         } elseif ($template->isUseJournalDefault()) {
             $GLOBALS[$globalKey] = false;
-            array_merge($criteria, ['journal' => null, 'journalDefault' => true]);
+            $criteria = array_merge($criteria, ['journal' => null, 'journalDefault' => true]);
             return $this->em->getRepository(MailTemplate::class)->findOneBy($criteria);
         } elseif (!$template->isActive()) {
             return false;

--- a/src/Ojs/JournalBundle/Listeners/AbstractJournalItemMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/AbstractJournalItemMailer.php
@@ -4,7 +4,7 @@ namespace Ojs\JournalBundle\Listeners;
 
 use Doctrine\ORM\EntityManager;
 use FOS\UserBundle\Model\UserInterface;
-use Ojs\CoreBundle\Service\OjsMailer;
+use Ojs\CoreBundle\Service\Mailer;
 use Ojs\JournalBundle\Event\JournalItemEvent;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -13,7 +13,7 @@ use Symfony\Component\Routing\RouterInterface;
 
 abstract class AbstractJournalItemMailer implements EventSubscriberInterface
 {
-    /** @var OjsMailer */
+    /** @var Mailer */
     protected $ojsMailer;
 
     /** @var EntityManager */
@@ -27,13 +27,13 @@ abstract class AbstractJournalItemMailer implements EventSubscriberInterface
 
     /**
      * AbstractJournalItemMailer constructor.
-     * @param OjsMailer $ojsMailer
+     * @param Mailer $ojsMailer
      * @param RegistryInterface $registry
      * @param TokenStorageInterface $tokenStorage
      * @param RouterInterface $router
      */
     public function __construct(
-        OjsMailer $ojsMailer,
+        Mailer $ojsMailer,
         RegistryInterface $registry,
         TokenStorageInterface $tokenStorage,
         RouterInterface $router

--- a/src/Ojs/JournalBundle/Listeners/AbstractJournalItemMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/AbstractJournalItemMailer.php
@@ -48,7 +48,7 @@ abstract class AbstractJournalItemMailer implements EventSubscriberInterface
     protected function sendMail(JournalItemEvent $itemEvent, $item, $action)
     {
         $journalItem = $itemEvent->getItem();
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $this->ojsMailer->sendToUser(
                 $user,
                 'A '.$item.' '.$action.' -> '.$journalItem->getJournal()->getTitle(),

--- a/src/Ojs/JournalBundle/Listeners/AbstractJournalItemMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/AbstractJournalItemMailer.php
@@ -14,7 +14,7 @@ use Symfony\Component\Routing\RouterInterface;
 abstract class AbstractJournalItemMailer implements EventSubscriberInterface
 {
     /** @var Mailer */
-    protected $ojsMailer;
+    protected $mailer;
 
     /** @var EntityManager */
     protected $em;
@@ -27,19 +27,19 @@ abstract class AbstractJournalItemMailer implements EventSubscriberInterface
 
     /**
      * AbstractJournalItemMailer constructor.
-     * @param Mailer $ojsMailer
+     * @param Mailer $mailer
      * @param RegistryInterface $registry
      * @param TokenStorageInterface $tokenStorage
      * @param RouterInterface $router
      */
     public function __construct(
-        Mailer $ojsMailer,
+        Mailer $mailer,
         RegistryInterface $registry,
         TokenStorageInterface $tokenStorage,
         RouterInterface $router
     )
     {
-        $this->ojsMailer = $ojsMailer;
+        $this->mailer = $mailer;
         $this->em = $registry->getManager();
         $this->user = $tokenStorage->getToken() ? $tokenStorage->getToken()->getUser(): null;
         $this->router = $router;
@@ -48,8 +48,8 @@ abstract class AbstractJournalItemMailer implements EventSubscriberInterface
     protected function sendMail(JournalItemEvent $itemEvent, $item, $action)
     {
         $journalItem = $itemEvent->getItem();
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $this->ojsMailer->sendToUser(
+        foreach ($this->mailer->getJournalStaff() as $user) {
+            $this->mailer->sendToUser(
                 $user,
                 'A '.$item.' '.$action.' -> '.$journalItem->getJournal()->getTitle(),
                 'A '.$item.' '.$action.' -> '.$journalItem->getJournal()->getTitle()

--- a/src/Ojs/JournalBundle/Listeners/ArticleMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/ArticleMailer.php
@@ -32,7 +32,7 @@ class ArticleMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'journal'           => (string)$itemEvent->getItem()->getJournal(),
                 'article.title'     => $itemEvent->getItem()->getTitle(),
@@ -59,7 +59,7 @@ class ArticleMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'journal'           => (string)$itemEvent->getItem()->getJournal(),
                 'article.title'     => $itemEvent->getItem()->getTitle(),
@@ -86,7 +86,7 @@ class ArticleMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'journal'           => (string)$itemEvent->getItem()->getJournal(),
                 'article.title'     => $itemEvent->getItem()->getTitle(),
@@ -116,7 +116,7 @@ class ArticleMailer extends AbstractJournalItemMailer
         if(!$getMailEvent){
             return;
         }
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'journal'               => (string)$itemEvent->getItem()->getJournal(),
                 'article.title'         => $itemEvent->getItem()->getTitle(),

--- a/src/Ojs/JournalBundle/Listeners/ArticleMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/ArticleMailer.php
@@ -76,8 +76,8 @@ class ArticleMailer extends AbstractJournalItemMailer
         /** @var Article $article */
         $article = $event->getItem();
         $journal = $article->getJournal();
-        $users = array_merge($this->ojsMailer->getJournalStaff(), $extraUsers);
+        $users = array_merge($this->mailer->getJournalStaff(), $extraUsers);
         $params = array_merge(['journal' => (string) $journal, 'article.title' => $article->getTitle()], $extraParams);
-        $this->ojsMailer->sendEventMail($name, $users, $params, $journal);
+        $this->mailer->sendEventMail($name, $users, $params, $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/ArticleMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/ArticleMailer.php
@@ -27,7 +27,7 @@ class ArticleMailer extends AbstractJournalItemMailer
      */
     public function onArticlePostCreate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(ArticleEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(ArticleEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -54,7 +54,7 @@ class ArticleMailer extends AbstractJournalItemMailer
      */
     public function onArticlePostUpdate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(ArticleEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(ArticleEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -81,7 +81,7 @@ class ArticleMailer extends AbstractJournalItemMailer
      */
     public function onArticlePreDelete(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(ArticleEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(ArticleEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -112,7 +112,7 @@ class ArticleMailer extends AbstractJournalItemMailer
         $article = $itemEvent->getItem();
         $submitterUser = $article->getSubmitterUser();
 
-        $getMailEvent = $this->ojsMailer->getEventByName(ArticleEvents::POST_SUBMIT, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(ArticleEvents::POST_SUBMIT, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }

--- a/src/Ojs/JournalBundle/Listeners/BoardMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/BoardMailer.php
@@ -34,7 +34,7 @@ class BoardMailer extends AbstractJournalItemMailer
         }
         $item->setCurrentLocale($this->ojsMailer->locale);
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'journal'           => (string)$item->getJournal(),
                 'board'             => (string)$item,
@@ -61,7 +61,7 @@ class BoardMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'journal'           => (string)$itemEvent->getItem()->getJournal(),
                 'board'             => (string)$itemEvent->getItem(),
@@ -88,7 +88,7 @@ class BoardMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'journal'           => (string)$itemEvent->getItem()->getJournal(),
                 'board'             => (string)$itemEvent->getItem(),

--- a/src/Ojs/JournalBundle/Listeners/BoardMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/BoardMailer.php
@@ -28,7 +28,7 @@ class BoardMailer extends AbstractJournalItemMailer
     {
         /** @var Board $item */
         $item = $itemEvent->getItem();
-        $getMailEvent = $this->ojsMailer->getEventByName(BoardEvents::POST_CREATE, null, $item->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(BoardEvents::POST_CREATE, null, $item->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -56,7 +56,7 @@ class BoardMailer extends AbstractJournalItemMailer
      */
     public function onBoardPostUpdate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(BoardEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(BoardEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -83,7 +83,7 @@ class BoardMailer extends AbstractJournalItemMailer
      */
     public function onBoardPreDelete(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(BoardEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(BoardEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }

--- a/src/Ojs/JournalBundle/Listeners/BoardMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/BoardMailer.php
@@ -53,13 +53,13 @@ class BoardMailer extends AbstractJournalItemMailer
         /** @var Board $board */
         $board = $event->getItem();
         $journal = $board->getJournal();
-        $staff = $this->ojsMailer->getJournalStaff();
+        $staff = $this->mailer->getJournalStaff();
 
         $params = [
             'journal' => (string) $journal,
             'board'   => (string) $board,
         ];
 
-        $this->ojsMailer->sendEventMail($name, $staff, $params, $journal);
+        $this->mailer->sendEventMail($name, $staff, $params, $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/IssueMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/IssueMailer.php
@@ -56,13 +56,13 @@ class IssueMailer extends AbstractJournalItemMailer
         /** @var Issue $issue */
         $issue = $event->getItem();
         $journal = $issue->getJournal();
-        $staff = $this->ojsMailer->getJournalStaff();
+        $staff = $this->mailer->getJournalStaff();
 
         $params = [
             'journal' => (string) $journal,
             'issue'   => (string) $issue,
         ];
 
-        $this->ojsMailer->sendEventMail($name, $staff, $params, $journal);
+        $this->mailer->sendEventMail($name, $staff, $params, $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/IssueMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/IssueMailer.php
@@ -30,7 +30,7 @@ class IssueMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'journal'           => (string)$itemEvent->getItem()->getJournal(),
                 'issue'             => (string)$itemEvent->getItem(),
@@ -57,7 +57,7 @@ class IssueMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'journal'           => (string)$itemEvent->getItem()->getJournal(),
                 'issue'             => (string)$itemEvent->getItem(),
@@ -84,7 +84,7 @@ class IssueMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'journal'           => (string)$itemEvent->getItem()->getJournal(),
                 'issue'             => (string)$itemEvent->getItem(),

--- a/src/Ojs/JournalBundle/Listeners/IssueMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/IssueMailer.php
@@ -2,9 +2,9 @@
 
 namespace Ojs\JournalBundle\Listeners;
 
+use Ojs\JournalBundle\Entity\Issue;
 use Ojs\JournalBundle\Event\Issue\IssueEvents;
 use Ojs\JournalBundle\Event\JournalItemEvent;
-use Ojs\UserBundle\Entity\User;
 
 class IssueMailer extends AbstractJournalItemMailer
 {
@@ -13,91 +13,56 @@ class IssueMailer extends AbstractJournalItemMailer
      */
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             IssueEvents::POST_CREATE => 'onIssuePostCreate',
             IssueEvents::POST_UPDATE => 'onIssuePostUpdate',
-            IssueEvents::PRE_DELETE => 'onIssuePreDelete',
-        );
+            IssueEvents::PRE_DELETE  => 'onIssuePreDelete',
+        ];
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onIssuePostCreate(JournalItemEvent $itemEvent)
+    public function onIssuePostCreate(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(IssueEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'journal'           => (string)$itemEvent->getItem()->getJournal(),
-                'issue'             => (string)$itemEvent->getItem(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+
+        $this->sendIssueMail($event, IssueEvents::POST_CREATE);
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onIssuePostUpdate(JournalItemEvent $itemEvent)
+    public function onIssuePostUpdate(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(IssueEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'journal'           => (string)$itemEvent->getItem()->getJournal(),
-                'issue'             => (string)$itemEvent->getItem(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+
+        $this->sendIssueMail($event, IssueEvents::POST_UPDATE);
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onIssuePreDelete(JournalItemEvent $itemEvent)
+    public function onIssuePreDelete(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(IssueEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'journal'           => (string)$itemEvent->getItem()->getJournal(),
-                'issue'             => (string)$itemEvent->getItem(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+
+        $this->sendIssueMail($event, IssueEvents::PRE_DELETE);
+    }
+
+    /**
+     * @param JournalItemEvent $event
+     * @param string $name
+     */
+    private function sendIssueMail(JournalItemEvent $event, string $name)
+    {
+        /** @var Issue $issue */
+        $issue = $event->getItem();
+        $journal = $issue->getJournal();
+        $staff = $this->ojsMailer->getJournalStaff();
+
+        $params = [
+            'journal' => (string) $journal,
+            'issue'   => (string) $issue,
+        ];
+
+        $this->ojsMailer->sendEventMail($name, $staff, $params, $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/IssueMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/IssueMailer.php
@@ -25,7 +25,7 @@ class IssueMailer extends AbstractJournalItemMailer
      */
     public function onIssuePostCreate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(IssueEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(IssueEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -52,7 +52,7 @@ class IssueMailer extends AbstractJournalItemMailer
      */
     public function onIssuePostUpdate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(IssueEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(IssueEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -79,7 +79,7 @@ class IssueMailer extends AbstractJournalItemMailer
      */
     public function onIssuePreDelete(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(IssueEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(IssueEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }

--- a/src/Ojs/JournalBundle/Listeners/JournalAnnouncementMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalAnnouncementMailer.php
@@ -53,13 +53,13 @@ class JournalAnnouncementMailer extends AbstractJournalItemMailer
         /** @var JournalAnnouncement $announcement */
         $announcement = $event->getItem();
         $journal = $announcement->getJournal();
-        $staff = $this->ojsMailer->getJournalStaff();
+        $staff = $this->mailer->getJournalStaff();
 
         $params = [
             'journal'      => (string) $journal,
             'announcement' => (string) $announcement,
         ];
 
-        $this->ojsMailer->sendEventMail($name, $staff, $params, $journal);
+        $this->mailer->sendEventMail($name, $staff, $params, $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/JournalAnnouncementMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalAnnouncementMailer.php
@@ -30,7 +30,7 @@ class JournalAnnouncementMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'journal'           => (string)$itemEvent->getItem()->getJournal(),
                 'announcement'      => $itemEvent->getItem()->getTitleTranslations(),
@@ -57,7 +57,7 @@ class JournalAnnouncementMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'journal'           => (string)$itemEvent->getItem()->getJournal(),
                 'announcement'      => $itemEvent->getItem()->getTitleTranslations(),
@@ -84,7 +84,7 @@ class JournalAnnouncementMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'journal'           => (string)$itemEvent->getItem()->getJournal(),
                 'announcement'      => $itemEvent->getItem()->getTitleTranslations(),

--- a/src/Ojs/JournalBundle/Listeners/JournalAnnouncementMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalAnnouncementMailer.php
@@ -2,9 +2,9 @@
 
 namespace Ojs\JournalBundle\Listeners;
 
+use Ojs\JournalBundle\Entity\JournalAnnouncement;
 use Ojs\JournalBundle\Event\JournalAnnouncement\JournalAnnouncementEvents;
 use Ojs\JournalBundle\Event\JournalItemEvent;
-use Ojs\UserBundle\Entity\User;
 
 class JournalAnnouncementMailer extends AbstractJournalItemMailer
 {
@@ -13,91 +13,53 @@ class JournalAnnouncementMailer extends AbstractJournalItemMailer
      */
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             JournalAnnouncementEvents::POST_CREATE => 'onJournalAnnouncementPostCreate',
             JournalAnnouncementEvents::POST_UPDATE => 'onJournalAnnouncementPostUpdate',
-            JournalAnnouncementEvents::PRE_DELETE => 'onJournalAnnouncementPreDelete',
-        );
+            JournalAnnouncementEvents::PRE_DELETE  => 'onJournalAnnouncementPreDelete',
+        ];
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalAnnouncementPostCreate(JournalItemEvent $itemEvent)
+    public function onJournalAnnouncementPostCreate(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalAnnouncementEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'journal'           => (string)$itemEvent->getItem()->getJournal(),
-                'announcement'      => $itemEvent->getItem()->getTitleTranslations(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendAnnouncementMail($event, JournalAnnouncementEvents::POST_CREATE);
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalAnnouncementPostUpdate(JournalItemEvent $itemEvent)
+    public function onJournalAnnouncementPostUpdate(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalAnnouncementEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'journal'           => (string)$itemEvent->getItem()->getJournal(),
-                'announcement'      => $itemEvent->getItem()->getTitleTranslations(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendAnnouncementMail($event, JournalAnnouncementEvents::POST_UPDATE);
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalAnnouncementPreDelete(JournalItemEvent $itemEvent)
+    public function onJournalAnnouncementPreDelete(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalAnnouncementEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'journal'           => (string)$itemEvent->getItem()->getJournal(),
-                'announcement'      => $itemEvent->getItem()->getTitleTranslations(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendAnnouncementMail($event, JournalAnnouncementEvents::PRE_DELETE);
+    }
+
+    /**
+     * @param JournalItemEvent $event
+     * @param string $name
+     */
+    private function sendAnnouncementMail(JournalItemEvent $event, string $name)
+    {
+        /** @var JournalAnnouncement $announcement */
+        $announcement = $event->getItem();
+        $journal = $announcement->getJournal();
+        $staff = $this->ojsMailer->getJournalStaff();
+
+        $params = [
+            'journal'      => (string) $journal,
+            'announcement' => (string) $announcement,
+        ];
+
+        $this->ojsMailer->sendEventMail($name, $staff, $params, $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/JournalAnnouncementMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalAnnouncementMailer.php
@@ -25,7 +25,7 @@ class JournalAnnouncementMailer extends AbstractJournalItemMailer
      */
     public function onJournalAnnouncementPostCreate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalAnnouncementEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalAnnouncementEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -52,7 +52,7 @@ class JournalAnnouncementMailer extends AbstractJournalItemMailer
      */
     public function onJournalAnnouncementPostUpdate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalAnnouncementEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalAnnouncementEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -79,7 +79,7 @@ class JournalAnnouncementMailer extends AbstractJournalItemMailer
      */
     public function onJournalAnnouncementPreDelete(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalAnnouncementEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalAnnouncementEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }

--- a/src/Ojs/JournalBundle/Listeners/JournalContactMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalContactMailer.php
@@ -49,8 +49,8 @@ class JournalContactMailer extends AbstractJournalItemMailer
         /** @var JournalContact */
         $contact = $event->getItem();
         $journal = $contact->getJournal();
-        $staff = $this->ojsMailer->getJournalStaff();
+        $staff = $this->mailer->getJournalStaff();
         $params = ['contact' => (string) $contact];
-        $this->ojsMailer->sendEventMail($name, $staff, $params, $journal);
+        $this->mailer->sendEventMail($name, $staff, $params, $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/JournalContactMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalContactMailer.php
@@ -25,7 +25,7 @@ class JournalContactMailer extends AbstractJournalItemMailer
      */
     public function onJournalContactPostCreate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalContactEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalContactEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -51,7 +51,7 @@ class JournalContactMailer extends AbstractJournalItemMailer
      */
     public function onJournalContactPostUpdate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalContactEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalContactEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -77,7 +77,7 @@ class JournalContactMailer extends AbstractJournalItemMailer
      */
     public function onJournalContactPreDelete(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalContactEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalContactEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }

--- a/src/Ojs/JournalBundle/Listeners/JournalContactMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalContactMailer.php
@@ -30,7 +30,7 @@ class JournalContactMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'contact'           => (string)$itemEvent->getItem(),
                 'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
@@ -56,7 +56,7 @@ class JournalContactMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'contact'           => (string)$itemEvent->getItem(),
                 'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
@@ -82,7 +82,7 @@ class JournalContactMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'contact'           => (string)$itemEvent->getItem(),
                 'done.by'           => $this->ojsMailer->currentUser()->getUsername(),

--- a/src/Ojs/JournalBundle/Listeners/JournalIndexMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalIndexMailer.php
@@ -25,7 +25,7 @@ class JournalIndexMailer extends AbstractJournalItemMailer
      */
     public function onJournalIndexPostCreate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalIndexEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalIndexEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -53,7 +53,7 @@ class JournalIndexMailer extends AbstractJournalItemMailer
      */
     public function onJournalIndexPostUpdate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalIndexEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalIndexEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -79,7 +79,7 @@ class JournalIndexMailer extends AbstractJournalItemMailer
      */
     public function onJournalIndexPreDelete(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalIndexEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalIndexEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }

--- a/src/Ojs/JournalBundle/Listeners/JournalIndexMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalIndexMailer.php
@@ -53,13 +53,13 @@ class JournalIndexMailer extends AbstractJournalItemMailer
         /** @var JournalIndex $index */
         $index = $event->getItem();
         $journal = $index->getJournal();
-        $staff = $this->ojsMailer->getJournalStaff();
+        $staff = $this->mailer->getJournalStaff();
 
         $params = [
             'journal' => (string) $journal,
             'index'   => (string) $index,
         ];
 
-        $this->ojsMailer->sendEventMail($name, $staff, $params, $journal);
+        $this->mailer->sendEventMail($name, $staff, $params, $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/JournalIndexMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalIndexMailer.php
@@ -29,7 +29,7 @@ class JournalIndexMailer extends AbstractJournalItemMailer
         if(!$getMailEvent){
             return;
         }
-        $mailUsers = array_merge($this->ojsMailer->getJournalRelatedUsers(), $this->ojsMailer->getAdminUsers());
+        $mailUsers = array_merge($this->ojsMailer->getJournalStaff(), $this->ojsMailer->getAdmins());
         /** @var User $user */
         foreach ($mailUsers as $user) {
             $transformParams = [
@@ -58,7 +58,7 @@ class JournalIndexMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'index'             => (string)$itemEvent->getItem(),
                 'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
@@ -84,7 +84,7 @@ class JournalIndexMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'index'             => (string)$itemEvent->getItem(),
                 'done.by'           => $this->ojsMailer->currentUser()->getUsername(),

--- a/src/Ojs/JournalBundle/Listeners/JournalIndexMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalIndexMailer.php
@@ -2,9 +2,9 @@
 
 namespace Ojs\JournalBundle\Listeners;
 
-use Ojs\JournalBundle\Event\JournalItemEvent;
+use Ojs\JournalBundle\Entity\JournalIndex;
 use Ojs\JournalBundle\Event\JournalIndex\JournalIndexEvents;
-use Ojs\UserBundle\Entity\User;
+use Ojs\JournalBundle\Event\JournalItemEvent;
 
 class JournalIndexMailer extends AbstractJournalItemMailer
 {
@@ -13,90 +13,53 @@ class JournalIndexMailer extends AbstractJournalItemMailer
      */
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             JournalIndexEvents::POST_CREATE => 'onJournalIndexPostCreate',
             JournalIndexEvents::POST_UPDATE => 'onJournalIndexPostUpdate',
-            JournalIndexEvents::PRE_DELETE => 'onJournalIndexPreDelete',
-        );
+            JournalIndexEvents::PRE_DELETE  => 'onJournalIndexPreDelete',
+        ];
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalIndexPostCreate(JournalItemEvent $itemEvent)
+    public function onJournalIndexPostCreate(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalIndexEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        $mailUsers = array_merge($this->ojsMailer->getJournalStaff(), $this->ojsMailer->getAdmins());
-        /** @var User $user */
-        foreach ($mailUsers as $user) {
-            $transformParams = [
-                'index'             => (string)$itemEvent->getItem(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-                'journal'           => (string)$itemEvent->getItem()->getJournal(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendIndexMail($event, JournalIndexEvents::POST_CREATE);
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalIndexPostUpdate(JournalItemEvent $itemEvent)
+    public function onJournalIndexPostUpdate(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalIndexEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'index'             => (string)$itemEvent->getItem(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendIndexMail($event, JournalIndexEvents::POST_UPDATE);
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalIndexPreDelete(JournalItemEvent $itemEvent)
+    public function onJournalIndexPreDelete(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalIndexEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'index'             => (string)$itemEvent->getItem(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendIndexMail($event, JournalIndexEvents::PRE_DELETE);
+    }
+
+    /**
+     * @param JournalItemEvent $event
+     * @param string $name
+     */
+    private function sendIndexMail(JournalItemEvent $event, string $name)
+    {
+        /** @var JournalIndex $index */
+        $index = $event->getItem();
+        $journal = $index->getJournal();
+        $staff = $this->ojsMailer->getJournalStaff();
+
+        $params = [
+            'journal' => (string) $journal,
+            'index'   => (string) $index,
+        ];
+
+        $this->ojsMailer->sendEventMail($name, $staff, $params, $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/JournalMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalMailer.php
@@ -20,9 +20,9 @@ class JournalMailer extends AbstractJournalItemMailer
      */
     public function onJournalPostUpdate(JournalEvent $event)
     {
-        $this->ojsMailer->sendEventMail(
+        $this->mailer->sendEventMail(
             JournalEvents::POST_UPDATE,
-            $this->ojsMailer->getJournalStaff(),
+            $this->mailer->getJournalStaff(),
             ['journal' => (string) $event->getJournal()],
             $event->getJournal()
         );

--- a/src/Ojs/JournalBundle/Listeners/JournalMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalMailer.php
@@ -23,7 +23,7 @@ class JournalMailer extends AbstractJournalItemMailer
      */
     public function onJournalPostUpdate(JournalEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalEvents::POST_UPDATE);
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalEvents::POST_UPDATE);
         if(!$getMailEvent){
             return;
         }

--- a/src/Ojs/JournalBundle/Listeners/JournalMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalMailer.php
@@ -4,7 +4,6 @@ namespace Ojs\JournalBundle\Listeners;
 
 use Ojs\JournalBundle\Event\JournalEvent;
 use Ojs\JournalBundle\Event\JournalEvents;
-use Ojs\UserBundle\Entity\User;
 
 class JournalMailer extends AbstractJournalItemMailer
 {
@@ -13,9 +12,7 @@ class JournalMailer extends AbstractJournalItemMailer
      */
     public static function getSubscribedEvents()
     {
-        return array(
-            JournalEvents::POST_UPDATE => 'onJournalPostUpdate'
-        );
+        return [JournalEvents::POST_UPDATE => 'onJournalPostUpdate'];
     }
 
     /**
@@ -23,24 +20,11 @@ class JournalMailer extends AbstractJournalItemMailer
      */
     public function onJournalPostUpdate(JournalEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalEvents::POST_UPDATE);
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'journal'           => (string)$event->getJournal(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->ojsMailer->sendEventMail(
+            JournalEvents::POST_UPDATE,
+            $this->ojsMailer->getJournalStaff(),
+            ['journal' => (string) $event->getJournal()],
+            $event->getJournal()
+        );
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/JournalMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalMailer.php
@@ -28,7 +28,7 @@ class JournalMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'journal'           => (string)$event->getJournal(),
                 'done.by'           => $this->ojsMailer->currentUser()->getUsername(),

--- a/src/Ojs/JournalBundle/Listeners/JournalPageMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalPageMailer.php
@@ -49,8 +49,8 @@ class JournalPageMailer extends AbstractJournalItemMailer
         /** @var JournalPage $page */
         $page = $event->getItem();
         $journal = $page->getJournal();
-        $staff = $this->ojsMailer->getJournalStaff();
+        $staff = $this->mailer->getJournalStaff();
         $params = ['page' => $page->getTitleTranslations()];
-        $this->ojsMailer->sendEventMail($name, $staff, $params, $journal);
+        $this->mailer->sendEventMail($name, $staff, $params, $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/JournalPageMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalPageMailer.php
@@ -2,9 +2,9 @@
 
 namespace Ojs\JournalBundle\Listeners;
 
+use Ojs\JournalBundle\Entity\JournalPage;
 use Ojs\JournalBundle\Event\JournalItemEvent;
 use Ojs\JournalBundle\Event\JournalPage\JournalPageEvents;
-use Ojs\UserBundle\Entity\User;
 
 class JournalPageMailer extends AbstractJournalItemMailer
 {
@@ -13,88 +13,44 @@ class JournalPageMailer extends AbstractJournalItemMailer
      */
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             JournalPageEvents::POST_CREATE => 'onJournalPagePostCreate',
             JournalPageEvents::POST_UPDATE => 'onJournalPagePostUpdate',
-            JournalPageEvents::PRE_DELETE => 'onJournalPagePreDelete',
-        );
+            JournalPageEvents::PRE_DELETE  => 'onJournalPagePreDelete',
+        ];
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalPagePostCreate(JournalItemEvent $itemEvent)
+    public function onJournalPagePostCreate(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalPageEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'page'              => (string)$itemEvent->getItem(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendPageMail($event, JournalPageEvents::POST_CREATE);
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalPagePostUpdate(JournalItemEvent $itemEvent)
+    public function onJournalPagePostUpdate(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalPageEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'page'              => (string)$itemEvent->getItem(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendPageMail($event, JournalPageEvents::POST_UPDATE);
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalPagePreDelete(JournalItemEvent $itemEvent)
+    public function onJournalPagePreDelete(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalPageEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'page'              => $itemEvent->getItem()->getTitleTranslations(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendPageMail($event, JournalPageEvents::PRE_DELETE);
+    }
+
+    private function sendPageMail(JournalItemEvent $event, string $name)
+    {
+        /** @var JournalPage $page */
+        $page = $event->getItem();
+        $journal = $page->getJournal();
+        $staff = $this->ojsMailer->getJournalStaff();
+        $params = ['page' => $page->getTitleTranslations()];
+        $this->ojsMailer->sendEventMail($name, $staff, $params, $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/JournalPageMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalPageMailer.php
@@ -25,7 +25,7 @@ class JournalPageMailer extends AbstractJournalItemMailer
      */
     public function onJournalPagePostCreate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalPageEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalPageEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -51,7 +51,7 @@ class JournalPageMailer extends AbstractJournalItemMailer
      */
     public function onJournalPagePostUpdate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalPageEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalPageEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -77,7 +77,7 @@ class JournalPageMailer extends AbstractJournalItemMailer
      */
     public function onJournalPagePreDelete(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalPageEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalPageEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }

--- a/src/Ojs/JournalBundle/Listeners/JournalPageMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalPageMailer.php
@@ -30,7 +30,7 @@ class JournalPageMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'page'              => (string)$itemEvent->getItem(),
                 'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
@@ -56,7 +56,7 @@ class JournalPageMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'page'              => (string)$itemEvent->getItem(),
                 'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
@@ -82,7 +82,7 @@ class JournalPageMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'page'              => $itemEvent->getItem()->getTitleTranslations(),
                 'done.by'           => $this->ojsMailer->currentUser()->getUsername(),

--- a/src/Ojs/JournalBundle/Listeners/JournalPostMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalPostMailer.php
@@ -49,8 +49,8 @@ class JournalPostMailer extends AbstractJournalItemMailer
         /** @var JournalPost $post */
         $post = $event->getItem();
         $journal = $post->getJournal();
-        $staff = $this->ojsMailer->getJournalStaff();
+        $staff = $this->mailer->getJournalStaff();
         $params = ['post' => $post->getTitleTranslations()];
-        $this->ojsMailer->sendEventMail($name, $staff, $params, $journal);
+        $this->mailer->sendEventMail($name, $staff, $params, $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/JournalPostMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalPostMailer.php
@@ -31,7 +31,7 @@ class JournalPostMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'post'              => (string)$itemEvent->getItem(),
                 'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
@@ -57,7 +57,7 @@ class JournalPostMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'post'              => (string)$itemEvent->getItem(),
                 'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
@@ -83,7 +83,7 @@ class JournalPostMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'post'              => $itemEvent->getItem()->getTitleTranslations(),
                 'done.by'           => $this->ojsMailer->currentUser()->getUsername(),

--- a/src/Ojs/JournalBundle/Listeners/JournalPostMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalPostMailer.php
@@ -26,7 +26,7 @@ class JournalPostMailer extends AbstractJournalItemMailer
      */
     public function onJournalPostPostCreate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalPostEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalPostEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -52,7 +52,7 @@ class JournalPostMailer extends AbstractJournalItemMailer
      */
     public function onJournalPostPostUpdate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalPostEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalPostEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -78,7 +78,7 @@ class JournalPostMailer extends AbstractJournalItemMailer
      */
     public function onJournalPostPreDelete(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalPostEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalPostEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }

--- a/src/Ojs/JournalBundle/Listeners/JournalPostMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalPostMailer.php
@@ -5,7 +5,6 @@ namespace Ojs\JournalBundle\Listeners;
 use Ojs\JournalBundle\Entity\JournalPost;
 use Ojs\JournalBundle\Event\JournalItemEvent;
 use Ojs\JournalBundle\Event\JournalPost\JournalPostEvents;
-use Ojs\UserBundle\Entity\User;
 
 class JournalPostMailer extends AbstractJournalItemMailer
 {
@@ -14,88 +13,44 @@ class JournalPostMailer extends AbstractJournalItemMailer
      */
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             JournalPostEvents::POST_CREATE => 'onJournalPostPostCreate',
             JournalPostEvents::POST_UPDATE => 'onJournalPostPostUpdate',
-            JournalPostEvents::PRE_DELETE => 'onJournalPostPreDelete',
-        );
+            JournalPostEvents::PRE_DELETE  => 'onJournalPostPreDelete',
+        ];
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalPostPostCreate(JournalItemEvent $itemEvent)
+    public function onJournalPostPostCreate(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalPostEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'post'              => (string)$itemEvent->getItem(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendPostMail($event, JournalPostEvents::POST_CREATE);
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalPostPostUpdate(JournalItemEvent $itemEvent)
+    public function onJournalPostPostUpdate(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalPostEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'post'              => (string)$itemEvent->getItem(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendPostMail($event, JournalPostEvents::POST_UPDATE);
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalPostPreDelete(JournalItemEvent $itemEvent)
+    public function onJournalPostPreDelete(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalPostEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'post'              => $itemEvent->getItem()->getTitleTranslations(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendPostMail($event, JournalPostEvents::PRE_DELETE);
+    }
+
+    private function sendPostMail(JournalItemEvent $event, string $name)
+    {
+        /** @var JournalPost $post */
+        $post = $event->getItem();
+        $journal = $post->getJournal();
+        $staff = $this->ojsMailer->getJournalStaff();
+        $params = ['post' => $post->getTitleTranslations()];
+        $this->ojsMailer->sendEventMail($name, $staff, $params, $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/JournalSubmissionChecklistMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalSubmissionChecklistMailer.php
@@ -30,7 +30,7 @@ class JournalSubmissionChecklistMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'submission.checklist'  => (string)$itemEvent->getItem(),
                 'done.by'               => $this->ojsMailer->currentUser()->getUsername(),
@@ -56,7 +56,7 @@ class JournalSubmissionChecklistMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'submission.checklist'  => (string)$itemEvent->getItem(),
                 'done.by'               => $this->ojsMailer->currentUser()->getUsername(),
@@ -82,7 +82,7 @@ class JournalSubmissionChecklistMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'submission.checklist'  => (string)$itemEvent->getItem(),
                 'done.by'               => $this->ojsMailer->currentUser()->getUsername(),

--- a/src/Ojs/JournalBundle/Listeners/JournalSubmissionChecklistMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalSubmissionChecklistMailer.php
@@ -25,7 +25,7 @@ class JournalSubmissionChecklistMailer extends AbstractJournalItemMailer
      */
     public function onJournalSubmissionChecklistPostCreate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalSubmissionChecklistEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalSubmissionChecklistEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -51,7 +51,7 @@ class JournalSubmissionChecklistMailer extends AbstractJournalItemMailer
      */
     public function onJournalSubmissionChecklistPostUpdate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalSubmissionChecklistEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalSubmissionChecklistEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -77,7 +77,7 @@ class JournalSubmissionChecklistMailer extends AbstractJournalItemMailer
      */
     public function onJournalSubmissionChecklistPreDelete(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalSubmissionChecklistEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalSubmissionChecklistEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }

--- a/src/Ojs/JournalBundle/Listeners/JournalSubmissionChecklistMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalSubmissionChecklistMailer.php
@@ -49,8 +49,8 @@ class JournalSubmissionChecklistMailer extends AbstractJournalItemMailer
         /** @var SubmissionChecklist $checklist */
         $checklist = $event->getItem();
         $journal = $checklist->getJournal();
-        $staff = $this->ojsMailer->getJournalStaff();
+        $staff = $this->mailer->getJournalStaff();
         $params = ['submission.checklist' => (string) $checklist];
-        $this->ojsMailer->sendEventMail($name, $staff, $params, $journal);
+        $this->mailer->sendEventMail($name, $staff, $params, $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/JournalSubmissionChecklistMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalSubmissionChecklistMailer.php
@@ -2,9 +2,9 @@
 
 namespace Ojs\JournalBundle\Listeners;
 
+use Ojs\JournalBundle\Entity\SubmissionChecklist;
 use Ojs\JournalBundle\Event\JournalItemEvent;
 use Ojs\JournalBundle\Event\JournalSubmissionChecklist\JournalSubmissionChecklistEvents;
-use Ojs\UserBundle\Entity\User;
 
 class JournalSubmissionChecklistMailer extends AbstractJournalItemMailer
 {
@@ -13,88 +13,44 @@ class JournalSubmissionChecklistMailer extends AbstractJournalItemMailer
      */
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             JournalSubmissionChecklistEvents::POST_CREATE => 'onJournalSubmissionChecklistPostCreate',
             JournalSubmissionChecklistEvents::POST_UPDATE => 'onJournalSubmissionChecklistPostUpdate',
-            JournalSubmissionChecklistEvents::PRE_DELETE => 'onJournalSubmissionChecklistPreDelete',
-        );
+            JournalSubmissionChecklistEvents::PRE_DELETE  => 'onJournalSubmissionChecklistPreDelete',
+        ];
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalSubmissionChecklistPostCreate(JournalItemEvent $itemEvent)
+    public function onJournalSubmissionChecklistPostCreate(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalSubmissionChecklistEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'submission.checklist'  => (string)$itemEvent->getItem(),
-                'done.by'               => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username'     => $user->getUsername(),
-                'receiver.fullName'     => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendChecklistMail($event, JournalSubmissionChecklistEvents::POST_CREATE);
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalSubmissionChecklistPostUpdate(JournalItemEvent $itemEvent)
+    public function onJournalSubmissionChecklistPostUpdate(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalSubmissionChecklistEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'submission.checklist'  => (string)$itemEvent->getItem(),
-                'done.by'               => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username'     => $user->getUsername(),
-                'receiver.fullName'     => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendChecklistMail($event, JournalSubmissionChecklistEvents::POST_UPDATE);
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalSubmissionChecklistPreDelete(JournalItemEvent $itemEvent)
+    public function onJournalSubmissionChecklistPreDelete(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalSubmissionChecklistEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'submission.checklist'  => (string)$itemEvent->getItem(),
-                'done.by'               => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username'     => $user->getUsername(),
-                'receiver.fullName'     => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendChecklistMail($event, JournalSubmissionChecklistEvents::PRE_DELETE);
+    }
+
+    private function sendChecklistMail(JournalItemEvent $event, string $name)
+    {
+        /** @var SubmissionChecklist $checklist */
+        $checklist = $event->getItem();
+        $journal = $checklist->getJournal();
+        $staff = $this->ojsMailer->getJournalStaff();
+        $params = ['submission.checklist' => (string) $checklist];
+        $this->ojsMailer->sendEventMail($name, $staff, $params, $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/JournalSubmissionFileMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalSubmissionFileMailer.php
@@ -25,7 +25,7 @@ class JournalSubmissionFileMailer extends AbstractJournalItemMailer
      */
     public function onJournalSubmissionFilePostCreate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalSubmissionFileEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalSubmissionFileEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -51,7 +51,7 @@ class JournalSubmissionFileMailer extends AbstractJournalItemMailer
      */
     public function onJournalSubmissionFilePostUpdate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalSubmissionFileEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalSubmissionFileEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -77,7 +77,7 @@ class JournalSubmissionFileMailer extends AbstractJournalItemMailer
      */
     public function onJournalSubmissionFilePreDelete(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalSubmissionFileEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalSubmissionFileEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }

--- a/src/Ojs/JournalBundle/Listeners/JournalSubmissionFileMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalSubmissionFileMailer.php
@@ -30,7 +30,7 @@ class JournalSubmissionFileMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'submission.file'       => (string)$itemEvent->getItem(),
                 'done.by'               => $this->ojsMailer->currentUser()->getUsername(),
@@ -56,7 +56,7 @@ class JournalSubmissionFileMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'submission.file'       => (string)$itemEvent->getItem(),
                 'done.by'               => $this->ojsMailer->currentUser()->getUsername(),
@@ -82,7 +82,7 @@ class JournalSubmissionFileMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'submission.file'       => (string)$itemEvent->getItem(),
                 'done.by'               => $this->ojsMailer->currentUser()->getUsername(),

--- a/src/Ojs/JournalBundle/Listeners/JournalSubmissionFileMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalSubmissionFileMailer.php
@@ -2,9 +2,9 @@
 
 namespace Ojs\JournalBundle\Listeners;
 
+use Ojs\JournalBundle\Entity\JournalSubmissionFile;
 use Ojs\JournalBundle\Event\JournalItemEvent;
 use Ojs\JournalBundle\Event\JournalSubmissionFile\JournalSubmissionFileEvents;
-use Ojs\UserBundle\Entity\User;
 
 class JournalSubmissionFileMailer extends AbstractJournalItemMailer
 {
@@ -13,88 +13,44 @@ class JournalSubmissionFileMailer extends AbstractJournalItemMailer
      */
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             JournalSubmissionFileEvents::POST_CREATE => 'onJournalSubmissionFilePostCreate',
             JournalSubmissionFileEvents::POST_UPDATE => 'onJournalSubmissionFilePostUpdate',
-            JournalSubmissionFileEvents::PRE_DELETE => 'onJournalSubmissionFilePreDelete',
-        );
+            JournalSubmissionFileEvents::PRE_DELETE  => 'onJournalSubmissionFilePreDelete',
+        ];
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalSubmissionFilePostCreate(JournalItemEvent $itemEvent)
+    public function onJournalSubmissionFilePostCreate(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalSubmissionFileEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'submission.file'       => (string)$itemEvent->getItem(),
-                'done.by'               => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username'     => $user->getUsername(),
-                'receiver.fullName'     => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendFileMail($event, JournalSubmissionFileEvents::POST_CREATE);
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalSubmissionFilePostUpdate(JournalItemEvent $itemEvent)
+    public function onJournalSubmissionFilePostUpdate(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalSubmissionFileEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'submission.file'       => (string)$itemEvent->getItem(),
-                'done.by'               => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username'     => $user->getUsername(),
-                'receiver.fullName'     => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendFileMail($event, JournalSubmissionFileEvents::POST_UPDATE);
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalSubmissionFilePreDelete(JournalItemEvent $itemEvent)
+    public function onJournalSubmissionFilePreDelete(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalSubmissionFileEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'submission.file'       => (string)$itemEvent->getItem(),
-                'done.by'               => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username'     => $user->getUsername(),
-                'receiver.fullName'     => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendFileMail($event, JournalSubmissionFileEvents::PRE_DELETE);
+    }
+
+    private function sendFileMail(JournalItemEvent $event, string $name)
+    {
+        /** @var JournalSubmissionFile $file */
+        $file = $event->getItem();
+        $journal = $file->getJournal();
+        $staff = $this->ojsMailer->getJournalStaff();
+        $params = ['submission.file' => (string) $file];
+        $this->ojsMailer->sendEventMail($name, $staff, $params, $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/JournalSubmissionFileMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalSubmissionFileMailer.php
@@ -49,8 +49,8 @@ class JournalSubmissionFileMailer extends AbstractJournalItemMailer
         /** @var JournalSubmissionFile $file */
         $file = $event->getItem();
         $journal = $file->getJournal();
-        $staff = $this->ojsMailer->getJournalStaff();
+        $staff = $this->mailer->getJournalStaff();
         $params = ['submission.file' => (string) $file];
-        $this->ojsMailer->sendEventMail($name, $staff, $params, $journal);
+        $this->mailer->sendEventMail($name, $staff, $params, $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/JournalUserMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalUserMailer.php
@@ -27,7 +27,7 @@ class JournalUserMailer extends AbstractJournalItemMailer
      */
     public function onJournalUserPostCreate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalUserEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalUserEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -54,7 +54,7 @@ class JournalUserMailer extends AbstractJournalItemMailer
      */
     public function onJournalUserPostUpdate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalUserEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalUserEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -81,7 +81,7 @@ class JournalUserMailer extends AbstractJournalItemMailer
      */
     public function onJournalUserPreDelete(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalUserEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalUserEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -108,7 +108,7 @@ class JournalUserMailer extends AbstractJournalItemMailer
      */
     public function onJournalUserPostAddJournal(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(JournalUserEvents::POST_ADD_JOURNAL, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalUserEvents::POST_ADD_JOURNAL, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }

--- a/src/Ojs/JournalBundle/Listeners/JournalUserMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalUserMailer.php
@@ -5,7 +5,6 @@ namespace Ojs\JournalBundle\Listeners;
 use Ojs\JournalBundle\Entity\JournalUser;
 use Ojs\JournalBundle\Event\JournalItemEvent;
 use Ojs\JournalBundle\Event\JournalUser\JournalUserEvents;
-use Ojs\UserBundle\Entity\User;
 
 class JournalUserMailer extends AbstractJournalItemMailer
 {
@@ -14,119 +13,62 @@ class JournalUserMailer extends AbstractJournalItemMailer
      */
     public static function getSubscribedEvents()
     {
-        return array(
-            JournalUserEvents::POST_CREATE => 'onJournalUserPostCreate',
-            JournalUserEvents::POST_UPDATE => 'onJournalUserPostUpdate',
-            JournalUserEvents::PRE_DELETE => 'onJournalUserPreDelete',
+        return [
+            JournalUserEvents::POST_CREATE      => 'onJournalUserPostCreate',
+            JournalUserEvents::POST_UPDATE      => 'onJournalUserPostUpdate',
+            JournalUserEvents::PRE_DELETE       => 'onJournalUserPreDelete',
             JournalUserEvents::POST_ADD_JOURNAL => 'onJournalUserPostAddJournal',
-        );
+        ];
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalUserPostCreate(JournalItemEvent $itemEvent)
+    public function onJournalUserPostCreate(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalUserEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'journal'           => (string)$itemEvent->getItem()->getJournal(),
-                'journal.user'      => (string)$itemEvent->getItem(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendUserMail($event, JournalUserEvents::POST_CREATE);
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalUserPostUpdate(JournalItemEvent $itemEvent)
+    public function onJournalUserPostUpdate(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalUserEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'journal'           => (string)$itemEvent->getItem()->getJournal(),
-                'journal.user'      => (string)$itemEvent->getItem(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendUserMail($event, JournalUserEvents::POST_UPDATE);
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalUserPreDelete(JournalItemEvent $itemEvent)
+    public function onJournalUserPreDelete(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalUserEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'journal'           => (string)$itemEvent->getItem()->getJournal(),
-                'journal.user'      => (string)$itemEvent->getItem(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendUserMail($event, JournalUserEvents::PRE_DELETE);
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onJournalUserPostAddJournal(JournalItemEvent $itemEvent)
+    public function onJournalUserPostAddJournal(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(JournalUserEvents::POST_ADD_JOURNAL, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'journal'           => (string)$itemEvent->getItem()->getJournal(),
-                'journal.user'      => (string)$itemEvent->getItem(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendUserMail($event, JournalUserEvents::POST_ADD_JOURNAL);
+    }
+
+    /**
+     * @param JournalItemEvent $event
+     * @param string $name
+     */
+    private function sendUserMail(JournalItemEvent $event, string $name)
+    {
+        /** @var JournalUser $user */
+        $user = $event->getItem();
+        $journal = $user->getJournal();
+        $staff = $this->ojsMailer->getJournalStaff();
+
+        $params = [
+            'journal'      => (string) $journal,
+            'journal.user' => (string) $user,
+        ];
+
+        $this->ojsMailer->sendEventMail($name, $staff, $params, $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/JournalUserMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalUserMailer.php
@@ -32,7 +32,7 @@ class JournalUserMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'journal'           => (string)$itemEvent->getItem()->getJournal(),
                 'journal.user'      => (string)$itemEvent->getItem(),
@@ -59,7 +59,7 @@ class JournalUserMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'journal'           => (string)$itemEvent->getItem()->getJournal(),
                 'journal.user'      => (string)$itemEvent->getItem(),
@@ -86,7 +86,7 @@ class JournalUserMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'journal'           => (string)$itemEvent->getItem()->getJournal(),
                 'journal.user'      => (string)$itemEvent->getItem(),
@@ -113,7 +113,7 @@ class JournalUserMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'journal'           => (string)$itemEvent->getItem()->getJournal(),
                 'journal.user'      => (string)$itemEvent->getItem(),

--- a/src/Ojs/JournalBundle/Listeners/JournalUserMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/JournalUserMailer.php
@@ -62,13 +62,13 @@ class JournalUserMailer extends AbstractJournalItemMailer
         /** @var JournalUser $user */
         $user = $event->getItem();
         $journal = $user->getJournal();
-        $staff = $this->ojsMailer->getJournalStaff();
+        $staff = $this->mailer->getJournalStaff();
 
         $params = [
             'journal'      => (string) $journal,
             'journal.user' => (string) $user,
         ];
 
-        $this->ojsMailer->sendEventMail($name, $staff, $params, $journal);
+        $this->mailer->sendEventMail($name, $staff, $params, $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/SectionMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/SectionMailer.php
@@ -25,7 +25,7 @@ class SectionMailer extends AbstractJournalItemMailer
      */
     public function onSectionPostCreate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(SectionEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(SectionEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -51,7 +51,7 @@ class SectionMailer extends AbstractJournalItemMailer
      */
     public function onSectionPostUpdate(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(SectionEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(SectionEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }
@@ -77,7 +77,7 @@ class SectionMailer extends AbstractJournalItemMailer
      */
     public function onSectionPreDelete(JournalItemEvent $itemEvent)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(SectionEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(SectionEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
         if(!$getMailEvent){
             return;
         }

--- a/src/Ojs/JournalBundle/Listeners/SectionMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/SectionMailer.php
@@ -49,7 +49,7 @@ class SectionMailer extends AbstractJournalItemMailer
         /** @var Section $section */
         $section = $event->getItem();
         $journal = $section->getJournal();
-        $staff = $this->ojsMailer->getJournalStaff();
-        $this->ojsMailer->sendEventMail($name, $staff, ['section' => $section], $journal);
+        $staff = $this->mailer->getJournalStaff();
+        $this->mailer->sendEventMail($name, $staff, ['section' => $section], $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/SectionMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/SectionMailer.php
@@ -2,9 +2,9 @@
 
 namespace Ojs\JournalBundle\Listeners;
 
-use Ojs\JournalBundle\Event\Section\SectionEvents;
+use Ojs\JournalBundle\Entity\Section;
 use Ojs\JournalBundle\Event\JournalItemEvent;
-use Ojs\UserBundle\Entity\User;
+use Ojs\JournalBundle\Event\Section\SectionEvents;
 
 class SectionMailer extends AbstractJournalItemMailer
 {
@@ -13,88 +13,43 @@ class SectionMailer extends AbstractJournalItemMailer
      */
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             SectionEvents::POST_CREATE => 'onSectionPostCreate',
             SectionEvents::POST_UPDATE => 'onSectionPostUpdate',
-            SectionEvents::PRE_DELETE => 'onSectionPreDelete',
-        );
+            SectionEvents::PRE_DELETE  => 'onSectionPreDelete',
+        ];
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onSectionPostCreate(JournalItemEvent $itemEvent)
+    public function onSectionPostCreate(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(SectionEvents::POST_CREATE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'section'           => (string)$itemEvent->getItem(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendSectionMail($event, SectionEvents::POST_CREATE);
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onSectionPostUpdate(JournalItemEvent $itemEvent)
+    public function onSectionPostUpdate(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(SectionEvents::POST_UPDATE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'section'           => (string)$itemEvent->getItem(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendSectionMail($event, SectionEvents::POST_UPDATE);
     }
 
     /**
-     * @param JournalItemEvent $itemEvent
+     * @param JournalItemEvent $event
      */
-    public function onSectionPreDelete(JournalItemEvent $itemEvent)
+    public function onSectionPreDelete(JournalItemEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getTemplateByEvent(SectionEvents::PRE_DELETE, null, $itemEvent->getItem()->getJournal());
-        if(!$getMailEvent){
-            return;
-        }
-        /** @var User $user */
-        foreach ($this->ojsMailer->getJournalStaff() as $user) {
-            $transformParams = [
-                'section'           => (string)$itemEvent->getItem(),
-                'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
-                'receiver.username' => $user->getUsername(),
-                'receiver.fullName' => $user->getFullName(),
-            ];
-            $template = $this->ojsMailer->transformTemplate($getMailEvent->getTemplate(), $transformParams);
-            $this->ojsMailer->sendToUser(
-                $user,
-                $getMailEvent->getSubject(),
-                $template
-            );
-        }
+        $this->sendSectionMail($event, SectionEvents::PRE_DELETE);
+    }
+
+    private function sendSectionMail(JournalItemEvent $event, string $name)
+    {
+        /** @var Section $section */
+        $section = $event->getItem();
+        $journal = $section->getJournal();
+        $staff = $this->ojsMailer->getJournalStaff();
+        $this->ojsMailer->sendEventMail($name, $staff, ['section' => $section], $journal);
     }
 }

--- a/src/Ojs/JournalBundle/Listeners/SectionMailer.php
+++ b/src/Ojs/JournalBundle/Listeners/SectionMailer.php
@@ -30,7 +30,7 @@ class SectionMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'section'           => (string)$itemEvent->getItem(),
                 'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
@@ -56,7 +56,7 @@ class SectionMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'section'           => (string)$itemEvent->getItem(),
                 'done.by'           => $this->ojsMailer->currentUser()->getUsername(),
@@ -82,7 +82,7 @@ class SectionMailer extends AbstractJournalItemMailer
             return;
         }
         /** @var User $user */
-        foreach ($this->ojsMailer->getJournalRelatedUsers() as $user) {
+        foreach ($this->ojsMailer->getJournalStaff() as $user) {
             $transformParams = [
                 'section'           => (string)$itemEvent->getItem(),
                 'done.by'           => $this->ojsMailer->currentUser()->getUsername(),

--- a/src/Ojs/JournalBundle/Listeners/SubscriptionSubscriber.php
+++ b/src/Ojs/JournalBundle/Listeners/SubscriptionSubscriber.php
@@ -3,7 +3,7 @@
 namespace Ojs\JournalBundle\Listeners;
 
 use Doctrine\ORM\EntityManager;
-use Ojs\CoreBundle\Service\OjsMailer;
+use Ojs\CoreBundle\Service\Mailer;
 use Ojs\JournalBundle\Entity\JournalAnnouncement;
 use Ojs\JournalBundle\Event\JournalAnnouncement\JournalAnnouncementEvents;
 use Ojs\JournalBundle\Event\JournalItemEvent;
@@ -14,14 +14,14 @@ class SubscriptionSubscriber implements EventSubscriberInterface
     /** @var EntityManager */
     private $em;
 
-    /** @var OjsMailer */
+    /** @var Mailer */
     private $ojsMailer;
 
     /**
      * @param EntityManager $em
-     * @param OjsMailer $ojsMailer
+     * @param Mailer $ojsMailer
      */
-    public function __construct(EntityManager $em, OjsMailer $ojsMailer)
+    public function __construct(EntityManager $em, Mailer $ojsMailer)
     {
         $this->em = $em;
         $this->ojsMailer = $ojsMailer;

--- a/src/Ojs/JournalBundle/Resources/config/services.yml
+++ b/src/Ojs/JournalBundle/Resources/config/services.yml
@@ -91,6 +91,8 @@ services:
   ojs.mail_listener.journal_contact:
     class: Ojs\JournalBundle\Listeners\JournalContactMailer
     parent: ojs.mail_listener.journal_item
+    tags:
+      - { name: kernel.event_subscriber }
 
   ojs.mail_listener.journal_index:
     class: Ojs\JournalBundle\Listeners\JournalIndexMailer

--- a/src/Ojs/UserBundle/Entity/UserRepository.php
+++ b/src/Ojs/UserBundle/Entity/UserRepository.php
@@ -155,4 +155,18 @@ class UserRepository extends EntityRepository implements UserProviderInterface
 
         return $query->execute();
     }
+
+    /**
+     * @return \Doctrine\Common\Collections\Collection|User[]
+     * @link http://stackoverflow.com/a/16692911
+     */
+    public function findAdmins()
+    {
+        $qb = $this->createQueryBuilder('u');
+        $qb
+            ->select('u')
+            ->where('u.roles LIKE :roles')
+            ->setParameter('roles', '%ROLE_SUPER_ADMIN%');
+        return $qb->getQuery()->getResult();
+    }
 }

--- a/src/Ojs/UserBundle/EventListener/UserEventListener.php
+++ b/src/Ojs/UserBundle/EventListener/UserEventListener.php
@@ -47,7 +47,7 @@ class UserEventListener implements EventSubscriberInterface
      */
     public function onRegistrationCompleted(FilterUserResponseEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(FOSUserEvents::REGISTRATION_COMPLETED);
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(FOSUserEvents::REGISTRATION_COMPLETED);
         if(!$getMailEvent){
             return;
         }
@@ -71,7 +71,7 @@ class UserEventListener implements EventSubscriberInterface
      */
     public function onChangePasswordCompleted(GetResponseUserEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(FOSUserEvents::CHANGE_PASSWORD_COMPLETED);
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(FOSUserEvents::CHANGE_PASSWORD_COMPLETED);
         if(!$getMailEvent){
             return;
         }
@@ -95,7 +95,7 @@ class UserEventListener implements EventSubscriberInterface
      */
     public function onProfileEditCompleted(GetResponseUserEvent $event)
     {
-        $getMailEvent = $this->ojsMailer->getEventByName(FOSUserEvents::PROFILE_EDIT_COMPLETED);
+        $getMailEvent = $this->ojsMailer->getTemplateByEvent(FOSUserEvents::PROFILE_EDIT_COMPLETED);
         if(!$getMailEvent){
             return;
         }

--- a/src/Ojs/UserBundle/EventListener/UserEventListener.php
+++ b/src/Ojs/UserBundle/EventListener/UserEventListener.php
@@ -5,7 +5,7 @@ namespace Ojs\UserBundle\EventListener;
 use FOS\UserBundle\Event\FilterUserResponseEvent;
 use FOS\UserBundle\Event\GetResponseUserEvent;
 use FOS\UserBundle\FOSUserEvents;
-use Ojs\CoreBundle\Service\OjsMailer;
+use Ojs\CoreBundle\Service\Mailer;
 use Ojs\UserBundle\Entity\User;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
@@ -15,16 +15,16 @@ class UserEventListener implements EventSubscriberInterface
     /** @var RouterInterface */
     private $router;
 
-    /** @var OjsMailer */
+    /** @var Mailer */
     private $ojsMailer;
 
     /**
      * @param RouterInterface $router
-     * @param OjsMailer $ojsMailer
+     * @param Mailer $ojsMailer
      */
     public function __construct(
         RouterInterface $router,
-        OjsMailer $ojsMailer
+        Mailer $ojsMailer
     ) {
         $this->router = $router;
         $this->ojsMailer = $ojsMailer;


### PR DESCRIPTION
This PR simplifies and centralizes email sending logic and reduces the amount of duplicate code.

Most of the methods in mail listeners do the same thing: find a suitable template, replace placeholders with real values, find recipients and then send an email to each one of them. Instead of repeating this same mechanism everywhere, listener methods now call `sendEventMail` method (which is introduced with 6a62141) and pass whatever's different from the rest of the emails as parameters. This helps us to update email related code more easily since we won't need to touch every listener method if we want to make a modification.